### PR TITLE
feat: replace Symbols API Client with Versions API Client

### DIFF
--- a/spec/files/native/post-native-crash.ts
+++ b/spec/files/native/post-native-crash.ts
@@ -1,6 +1,6 @@
 import { BugSplatApiClient } from '@common';
 import { CrashPostClient, CrashType } from '@post';
-import { SymbolsApiClient } from '@symbols';
+import { VersionsApiClient } from '@versions';
 import { createUploadableFile } from '../create-bugsplat-file';
 
 export async function postNativeCrashAndSymbols(
@@ -12,7 +12,7 @@ export async function postNativeCrashAndSymbols(
     const exeFile = createUploadableFile('./spec/files/native/myConsoleCrasher.exe');
     const pdbFile = createUploadableFile('./spec/files/native/myConsoleCrasher.pdb');
     const files = [exeFile, pdbFile];
-    const symbolsApiClient = new SymbolsApiClient(authenticatedClient);
+    const symbolsApiClient = new VersionsApiClient(authenticatedClient);
     await symbolsApiClient.postSymbols(
         database,
         application,

--- a/src/common/data/table-data/table-data-client/table-data-client.spec.ts
+++ b/src/common/data/table-data/table-data-client/table-data-client.spec.ts
@@ -63,7 +63,7 @@ describe('TableDataClient', () => {
       pageSize = 9001;
       sortColumn = 'sorty';
       sortOrder = 'mcOrder';
-      const response = await service.getData({
+      const response = await service.postGetData({
         database,
         columnGroups,
         filterGroups,
@@ -130,7 +130,7 @@ describe('TableDataClient', () => {
     it('should return empty array if api returns null', async () => {
       bugSplatApiClient.fetch.and.resolveTo({ json: () => null });
 
-      const response = await service.getData({
+      const response = await service.postGetData({
         filterGroups,
         page,
         pageSize,

--- a/src/common/data/table-data/table-data-client/table-data-client.ts
+++ b/src/common/data/table-data/table-data-client/table-data-client.ts
@@ -5,7 +5,8 @@ export class TableDataClient {
 
   constructor(private _apiClient: ApiClient, private _url: string) { }
 
-  async getData(request: TableDataRequest): Promise<BugSplatResponse> {
+  // We use POST to get data in most cases because it supports longer queries
+  async postGetData(request: TableDataRequest): Promise<BugSplatResponse> {
     const factory = () => this._apiClient.createFormData();
     const formData = new TableDataFormDataBuilder(factory)
       .withDatabase(request.database)
@@ -23,7 +24,32 @@ export class TableDataClient {
       credentials: 'include',
       redirect: 'follow'
     };
-    const response = await this._apiClient.fetch(this._url, <RequestInit><unknown>init);
+    return this.makeRequest(this._url, <RequestInit><unknown>init);
+  }
+
+  async getData(request: TableDataRequest): Promise<BugSplatResponse> {
+    const factory = () => this._apiClient.createFormData();
+    const formData = new TableDataFormDataBuilder(factory)
+      .withDatabase(request.database)
+      .withFilterGroups(request.filterGroups)
+      .withColumnGroups(request.columnGroups)
+      .withPage(request.page)
+      .withPageSize(request.pageSize)
+      .withSortColumn(request.sortColumn)
+      .withSortOrder(request.sortOrder)
+      .entries();
+    const init = {
+      method: 'GET',
+      cache: 'no-cache',
+      credentials: 'include',
+      redirect: 'follow'
+    };
+    const queryParams = new URLSearchParams(formData).toString();
+    return this.makeRequest(`${this._url}?${queryParams}`, <RequestInit><unknown>init);
+  }
+
+  private async makeRequest(url: string, init: RequestInit): Promise<BugSplatResponse> {
+    const response = await this._apiClient.fetch(url, init);
     const responseData = await response.json();
     const rows = responseData ? responseData[0]?.Rows : [];
     const pageData = responseData ? responseData[0]?.PageData : {};

--- a/src/common/data/table-data/table-data-form-data-builder/table-data-form-data-builder.ts
+++ b/src/common/data/table-data/table-data-form-data-builder/table-data-form-data-builder.ts
@@ -7,7 +7,7 @@ export class TableDataFormDataBuilder {
 
   constructor(
     private _formDataFactory: () => FormData,
-    private _formParts: Record<string, string | number> = {},
+    private _formParts: Record<string, string> = {},
   ) { }
 
   withColumnGroups(groups: Array<string> | undefined): TableDataFormDataBuilder {
@@ -17,7 +17,7 @@ export class TableDataFormDataBuilder {
         this._formParts[`group${i}`] = group;
         groupsCount++;
       });
-      this._formParts['groupscount'] = groupsCount;
+      this._formParts['groupscount'] = `${groupsCount}`;
     }
 
     return this;
@@ -31,29 +31,29 @@ export class TableDataFormDataBuilder {
           group.filters.forEach((filter, i) => {
             const firstFilter = i === 0;
             const lastFilter = i === group.filters.length - 1;
-            this._formParts[`filtergroupopen${filtersCount}`] = firstFilter ? 1 : 0;
+            this._formParts[`filtergroupopen${filtersCount}`] = firstFilter ? '1' : '0';
             this._formParts[`filteroperator${filtersCount}`] = firstFilter ? group.groupOperator?.value : group.filterOperator?.value;
             this._formParts[`filterdatafield${filtersCount}`] = filter.filterDataField;
             this._formParts[`filtercondition${filtersCount}`] = filter.filterCondition;
             this._formParts[`filtervalue${filtersCount}`] = filter.filterValue;
-            this._formParts[`filtergroupclose${filtersCount}`] = lastFilter ? 1 : 0;
+            this._formParts[`filtergroupclose${filtersCount}`] = lastFilter ? '1' : '0';
             filtersCount++;
           });
         }
       });
-      this._formParts['filterscount'] = filtersCount;
+      this._formParts['filterscount'] = `${filtersCount}`;
     }
 
     return this;
   }
 
   withPage(page = 0): TableDataFormDataBuilder {
-    this._formParts.pagenum = page;
+    this._formParts.pagenum = `${page}`;
     return this;
   }
 
   withPageSize(pageSize = 10): TableDataFormDataBuilder {
-    this._formParts.pagesize = pageSize;
+    this._formParts.pagesize = `${pageSize}`;
     return this;
   }
 
@@ -90,6 +90,10 @@ export class TableDataFormDataBuilder {
       this._formParts.versions = versions.join(',');
     }
     return this;
+  }
+
+  entries(): Record<string, string> {
+    return this._formParts;
   }
 
   build(): FormData {

--- a/src/crashes/crashes-api-client/crashes-api-client.e2e.ts
+++ b/src/crashes/crashes-api-client/crashes-api-client.e2e.ts
@@ -3,6 +3,7 @@ import { ApiDataFilterGroup, BugSplatApiClient, FilterOperator } from '@common';
 import { CrashApiClient } from '@crash';
 import { CrashesApiClient } from '@crashes';
 import { postNativeCrash, postNativeCrashAndSymbols } from '@spec/files/native/post-native-crash';
+import { firstValueFrom, timer } from 'rxjs';
 
 describe('CrashesApiClient', () => {
     let crashClient: CrashApiClient;
@@ -59,6 +60,7 @@ describe('CrashesApiClient', () => {
             const pageSize = 2;
             const sortColumn = 'id';
             const sortOrder = 'asc';
+            await firstValueFrom(timer(2000)); // Prevent rate-limiting
             const newestCrashId = await postNativeCrash(
                 config.database,
                 application,

--- a/src/crashes/crashes-api-client/crashes-api-client.spec.ts
+++ b/src/crashes/crashes-api-client/crashes-api-client.spec.ts
@@ -31,8 +31,8 @@ describe('CrashesApiClient', () => {
         pageData = { coffee: 'black rifle' };
         rows = [{ id, Comments, IpAddress }];
         tableDataClientResponse = createFakeResponseBody(200, { pageData, rows });
-        tableDataClient = jasmine.createSpyObj('TableDataClient', ['getData']);
-        tableDataClient.getData.and.resolveTo(tableDataClientResponse);
+        tableDataClient = jasmine.createSpyObj('TableDataClient', ['postGetData']);
+        tableDataClient.postGetData.and.resolveTo(tableDataClientResponse);
         spyOn(TableDataClientModule, 'TableDataClient').and.returnValue(tableDataClient);
 
         sut = new CrashesApiClient(apiClient);
@@ -47,8 +47,8 @@ describe('CrashesApiClient', () => {
             result = await sut.getCrashes(request);
         });
 
-        it('should call getData with request', () => {
-            expect(tableDataClient.getData).toHaveBeenCalledWith(request);
+        it('should call postGetData with request', () => {
+            expect(tableDataClient.postGetData).toHaveBeenCalledWith(request);
         });
 
         it('should return value with Comments and IpAddress values mapped to lower-case', () => {

--- a/src/crashes/crashes-api-client/crashes-api-client.ts
+++ b/src/crashes/crashes-api-client/crashes-api-client.ts
@@ -10,7 +10,7 @@ export class CrashesApiClient {
     }
 
     async getCrashes(request: TableDataRequest): Promise<TableDataResponse<CrashesApiRow>> {
-        const response = await this._tableDataClient.getData(request);
+        const response = await this._tableDataClient.postGetData(request);
         const json = await response.json();
         const pageData = json.pageData;
         const rows = json.rows.map(row => new CrashesApiRow(row));

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,4 +3,4 @@ export * from './crash';
 export * from './crashes';
 export * from './events';
 export * from './post';
-export * from './symbols';
+export * from './versions';

--- a/src/symbols/index.ts
+++ b/src/symbols/index.ts
@@ -1,1 +1,0 @@
-export { SymbolsApiClient } from './symbols-api-client/symbols-api-client';

--- a/src/versions/index.ts
+++ b/src/versions/index.ts
@@ -1,1 +1,2 @@
 export { VersionsApiClient } from './versions-api-client/versions-api-client';
+export { VersionsApiRow } from './versions-api-row/versions-api-row';

--- a/src/versions/index.ts
+++ b/src/versions/index.ts
@@ -1,0 +1,1 @@
+export { VersionsApiClient } from './versions-api-client/versions-api-client';

--- a/src/versions/versions-api-client/versions-api-client.e2e.ts
+++ b/src/versions/versions-api-client/versions-api-client.e2e.ts
@@ -1,11 +1,11 @@
 import { BugSplatApiClient, UploadableFile } from '@common';
 import { config } from '@spec/config';
-import { SymbolsApiClient } from '@symbols';
+import { VersionsApiClient } from '@versions';
 import fs from 'fs';
 import path from 'path';
 
-describe('SymbolsApiClient', () => {
-    let client: SymbolsApiClient;
+describe('VersionsApiClient', () => {
+    let client: VersionsApiClient;
     const application = 'bugsplat-js-api-client';
     const version = '1.0.0';
 
@@ -15,7 +15,7 @@ describe('SymbolsApiClient', () => {
             config.password,
             config.host
         );
-        client = new SymbolsApiClient(bugsplat);
+        client = new VersionsApiClient(bugsplat);
     });
 
     describe('delete', () => {

--- a/src/versions/versions-api-client/versions-api-client.e2e.ts
+++ b/src/versions/versions-api-client/versions-api-client.e2e.ts
@@ -1,27 +1,85 @@
 import { BugSplatApiClient, UploadableFile } from '@common';
 import { config } from '@spec/config';
+import { postNativeCrashAndSymbols } from '@spec/files/native/post-native-crash';
 import { VersionsApiClient } from '@versions';
 import fs from 'fs';
 import path from 'path';
 
 describe('VersionsApiClient', () => {
     let client: VersionsApiClient;
-    const application = 'bugsplat-js-api-client';
-    const version = '1.0.0';
+    let database;
+    let application;
+    let version = '1.0.0';
 
     beforeEach(async () => {
+        database = config.database;
+        application = 'bugsplat-js-api-client';
+        version = `${Math.random() * 1000000}`;
+
         const bugsplat = await BugSplatApiClient.createAuthenticatedClientForNode(
             config.email,
             config.password,
             config.host
         );
+
+        await postNativeCrashAndSymbols(
+            bugsplat,
+            database,
+            application,
+            version
+        );
+
         client = new VersionsApiClient(bugsplat);
     });
 
-    describe('delete', () => {
+    describe('getVersions', () => {
+        it('should return 200 with a list of versions', async () => {
+            const result = await client.getVersions({ database });
+
+            const row = result.rows.find(row => row.appName === application && row.version === version);
+            expect(row).toBeTruthy();
+            expect(row?.appName).toEqual(application);
+            expect(row?.version).toEqual(version);
+            expect(Number(row?.size)).toBeGreaterThan(0);
+        });
+    });
+
+    describe('putFullDumps', () => {
+        it('should return invalid permissions because account is not licensed', async () => {
+            const result = await client.putFullDumps(
+                database,
+                application,
+                version,
+                true
+            );
+            const json = await result.json();
+
+            expect(result.status).toEqual(403);
+            expect(json.message).toEqual('Invalid permissions');
+        });
+    });
+
+    describe('putRetired', () => {
+        it('should return 200 for put with valid database, application, and version', async () => {
+            const retired = true;
+            
+            const result = await client.putRetired(
+                database,
+                application,
+                version,
+                retired
+            );
+            const json = await result.json();
+
+            expect(result.status).toEqual(200);
+            expect(json.retired).toEqual(retired ? 1 : 0);
+        });
+    });
+
+    describe('deleteSymbols', () => {
         it('should return 200 for delete with valid database, application and version', async () => {
             const response = await client.deleteSymbols(
-                config.database,
+                database,
                 application,
                 version
             );
@@ -30,14 +88,14 @@ describe('VersionsApiClient', () => {
         });
     });
 
-    describe('post', () => {
+    describe('postSymbols', () => {
         it('should return 200 for post with valid database, application, version and files', async () => {
             const filePath = './spec/files/js/index.js.map';
             const name = path.basename(filePath);
             const size = fs.statSync(filePath).size;
             const file = new UploadableFile(name, size, fs.createReadStream(filePath));
             const response = await client.postSymbols(
-                config.database,
+                database,
                 application,
                 version,
                 [file]

--- a/src/versions/versions-api-client/versions-api-client.e2e.ts
+++ b/src/versions/versions-api-client/versions-api-client.e2e.ts
@@ -45,17 +45,15 @@ describe('VersionsApiClient', () => {
     });
 
     describe('putFullDumps', () => {
-        it('should return invalid permissions because account is not licensed', async () => {
+        it('should return 403 because account is not licensed', async () => {
             const result = await client.putFullDumps(
                 database,
                 application,
                 version,
                 true
             );
-            const json = await result.json();
 
             expect(result.status).toEqual(403);
-            expect(json.message).toEqual('Invalid permissions');
         });
     });
 

--- a/src/versions/versions-api-client/versions-api-client.spec.ts
+++ b/src/versions/versions-api-client/versions-api-client.spec.ts
@@ -1,12 +1,12 @@
 import { createFakeBugSplatApiClient } from '@spec/fakes/common/bugsplat-api-client';
 import { createFakeFormData } from '@spec/fakes/common/form-data';
 import { createFakeResponseBody } from '@spec/fakes/common/response';
-import { SymbolsApiClient } from '@symbols';
+import { VersionsApiClient } from '@versions';
 import path from 'path';
 import { of } from 'rxjs';
 import * as S3ApiClientModule from '../../common/client/s3-api-client/s3-api-client';
 
-describe('SymbolsApiClient', () => {
+describe('VersionsApiClient', () => {
     const database = 'fred';
     const application = 'my-js-crasher';
     const version = '1.0.0';
@@ -16,7 +16,7 @@ describe('SymbolsApiClient', () => {
     let fakeSuccessResponse;
     let fakeS3ApiClient;
 
-    let symbolsApiClient: SymbolsApiClient;
+    let versionsApiClient: VersionsApiClient;
 
     beforeEach(() => {
         fakeFormData = createFakeFormData();
@@ -28,13 +28,13 @@ describe('SymbolsApiClient', () => {
         spyOn(S3ApiClientModule, 'S3ApiClient').and.returnValue(fakeS3ApiClient);
 
 
-        symbolsApiClient = new SymbolsApiClient(fakeBugSplatApiClient);
+        versionsApiClient = new VersionsApiClient(fakeBugSplatApiClient);
     });
     describe('deleteSymbols', () => {
         let result;
 
         beforeEach(async () => {
-            result = await symbolsApiClient.deleteSymbols(
+            result = await versionsApiClient.deleteSymbols(
                 database,
                 application,
                 version
@@ -43,7 +43,7 @@ describe('SymbolsApiClient', () => {
 
         it('should call fetch with route containing database, application and version', () => {
             expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith(
-                `/api/symbols?dbName=${database}&appName=${application}&appVersion=${version}`,
+                `/api/versions?database=${database}&appName=${application}&appVersion=${version}`,
                 jasmine.anything()
             );
         });
@@ -67,7 +67,7 @@ describe('SymbolsApiClient', () => {
                 const fakeErrorResponse = createFakeResponseBody(400);
                 fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
 
-                await expectAsync(symbolsApiClient.deleteSymbols(
+                await expectAsync(versionsApiClient.deleteSymbols(
                     database,
                     application,
                     version
@@ -79,7 +79,7 @@ describe('SymbolsApiClient', () => {
                 const fakeErroResponse = createFakeResponseBody(200, { Status: 'Failed', Error: message });
                 fakeBugSplatApiClient.fetch.and.resolveTo(fakeErroResponse);
 
-                await expectAsync(symbolsApiClient.deleteSymbols(
+                await expectAsync(versionsApiClient.deleteSymbols(
                     database,
                     application,
                     version
@@ -100,9 +100,9 @@ describe('SymbolsApiClient', () => {
             }];
             timer = jasmine.createSpy();
             timer.and.returnValue(of(0));
-            (<any>symbolsApiClient)._timer = timer;
+            (<any>versionsApiClient)._timer = timer;
 
-            result = await symbolsApiClient.postSymbols(
+            result = await versionsApiClient.postSymbols(
                 database,
                 application,
                 version,
@@ -111,7 +111,7 @@ describe('SymbolsApiClient', () => {
         });
 
         it('should append dbName, appName, appVersion, size and symFileName to FormData', () => {
-            expect(fakeFormData.append).toHaveBeenCalledWith('dbName', database);
+            expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
             expect(fakeFormData.append).toHaveBeenCalledWith('appName', application);
             expect(fakeFormData.append).toHaveBeenCalledWith('appVersion', version);
             expect(fakeFormData.append).toHaveBeenCalledWith('size', files[0].size.toString());
@@ -120,7 +120,7 @@ describe('SymbolsApiClient', () => {
 
         it('should call fetch with correct route', () => {
             expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith(
-                '/api/symbols',
+                '/api/versions',
                 jasmine.anything()
             );
         });
@@ -141,7 +141,7 @@ describe('SymbolsApiClient', () => {
         });
 
         it('should sleep between requests', () => {
-            expect((<any>symbolsApiClient)._timer).toHaveBeenCalledWith(1000);
+            expect((<any>versionsApiClient)._timer).toHaveBeenCalledWith(1000);
         });
 
         it('should return response', () => {
@@ -155,7 +155,7 @@ describe('SymbolsApiClient', () => {
                 const fakeErrorResponse = createFakeResponseBody(400);
                 fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
 
-                await expectAsync(symbolsApiClient.postSymbols(
+                await expectAsync(versionsApiClient.postSymbols(
                     database,
                     application,
                     version,
@@ -168,7 +168,7 @@ describe('SymbolsApiClient', () => {
                 const fakeErrorResponse = createFakeResponseBody(200, { Status: 'Failed', Error: message });
                 fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
 
-                await expectAsync(symbolsApiClient.postSymbols(
+                await expectAsync(versionsApiClient.postSymbols(
                     database,
                     application,
                     version,

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -1,9 +1,9 @@
 import { ApiClient, UploadableFile, BugSplatResponse, S3ApiClient } from '@common';
 import { lastValueFrom, timer } from 'rxjs';
 
-export class SymbolsApiClient {
+export class VersionsApiClient {
 
-    private readonly route = '/api/symbols';
+    private readonly route = '/api/versions';
 
     private _s3ApiClient: S3ApiClient;
     private _timer = timer;
@@ -17,7 +17,7 @@ export class SymbolsApiClient {
         application: string,
         version: string
     ): Promise<BugSplatResponse> {
-        const route = `${this.route}?dbName=${database}&appName=${application}&appVersion=${version}`;
+        const route = `${this.route}?database=${database}&appName=${application}&appVersion=${version}`;
         const init = {
             method: 'DELETE',
             cache: 'no-cache',
@@ -66,14 +66,14 @@ export class SymbolsApiClient {
     }
 
     private async getPresignedUrl(
-        dbName: string,
+        database: string,
         appName: string,
         appVersion: string,
         size: number,
         symFileName: string
     ): Promise<string> {
         const formData = this._client.createFormData();
-        formData.append('dbName', dbName);
+        formData.append('database', database);
         formData.append('appName', appName);
         formData.append('appVersion', appVersion);
         formData.append('size', size.toString());

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -1,15 +1,66 @@
-import { ApiClient, UploadableFile, BugSplatResponse, S3ApiClient } from '@common';
+import { ApiClient, UploadableFile, BugSplatResponse, S3ApiClient, TableDataClient, TableDataRequest, TableDataResponse } from '@common';
 import { lastValueFrom, timer } from 'rxjs';
+import { VersionsApiRow } from '../versions-api-row/versions-api-row';
 
 export class VersionsApiClient {
 
     private readonly route = '/api/versions';
 
     private _s3ApiClient: S3ApiClient;
+    private _tableDataClient: TableDataClient;
     private _timer = timer;
 
     constructor(private _client: ApiClient) {
         this._s3ApiClient = new S3ApiClient();
+        this._tableDataClient = new TableDataClient(this._client, this.route);
+    }
+
+    async getVersions(request: TableDataRequest): Promise<TableDataResponse<VersionsApiRow>> {
+        const response = await this._tableDataClient.getData(request);
+        const json = await response.json();
+        const pageData = json.pageData;
+        const rows = json.rows.map(row => new VersionsApiRow(row));
+
+        return {
+            rows,
+            pageData
+        };
+    }
+
+    async putFullDumps(
+        database: string,
+        application: string,
+        version: string,
+        fullDumps: boolean
+    ): Promise<BugSplatResponse> {
+        const fullDumpsFlag = fullDumps ? '1' : '0';
+        const route = `${this.route}?database=${database}&appName=${application}&appVersion=${version}&fullDumps=${fullDumpsFlag}`;
+        const init = {
+            method: 'PUT',
+            cache: 'no-cache',
+            credentials: 'include',
+            redirect: 'follow'
+        };
+
+        return this._client.fetch(route, <RequestInit>init);
+    }
+    
+    async putRetired(
+        database: string,
+        application: string,
+        version: string,
+        retired: boolean
+    ): Promise<BugSplatResponse> {
+        const retiredFlag = retired ? '1' : '0';
+        const route = `${this.route}?database=${database}&appName=${application}&appVersion=${version}&retired=${retiredFlag}`;
+        const init = {
+            method: 'PUT',
+            cache: 'no-cache',
+            credentials: 'include',
+            redirect: 'follow'
+        };
+
+        return this._client.fetch(route, <RequestInit>init);
     }
 
     async deleteSymbols(

--- a/src/versions/versions-api-row/versions-api-row.ts
+++ b/src/versions/versions-api-row/versions-api-row.ts
@@ -1,0 +1,60 @@
+import ac from 'argument-contracts';
+
+export interface VersionsApiResponseRow {
+  symbolId: string;
+  appName: string;
+  version: string;
+  lastUpdate: string;
+  firstReport: string;
+  lastReport: string;
+  size: string;
+  reportsPerDay: string | null;
+  rejectedCount: string;
+  retired: '0' | '1';
+  fullDumps: '0' | '1';
+}
+
+export class VersionsApiRow {
+  public symbolId: number;
+  public appName: string;
+  public version: string;
+  public lastUpdate: string;
+  public firstReport: string;
+  public lastReport: string;
+  public size: number;
+  public reportsPerDay: number;
+  public rejectedCount: number;
+  public retired: 0 | 1;
+  public fullDumps: 0 | 1;
+
+  constructor(rawApiRow: VersionsApiResponseRow) {
+    ac.assertType(rawApiRow, Object, 'rawApiRow');
+
+    let symbolId;
+    try {
+      symbolId = Number(rawApiRow.symbolId);
+    } catch (error) {
+      throw new TypeError(`symbolId should be parsable to int. Provided value: ${JSON.stringify(rawApiRow.symbolId)}. Inner Error: ${error}`);
+    }
+
+    const safeAppName = rawApiRow.appName ?? '';
+    const safeVersion = rawApiRow.version ?? '';
+    const safeReportsPerDay = rawApiRow.reportsPerDay ?? 0;
+    const safeRetired = rawApiRow.retired === '1' ? 1 : 0;
+    const safeFullDumps = rawApiRow.fullDumps === '1' ? 1 : 0;
+
+    this.symbolId = symbolId;
+    this.appName = safeAppName;
+    this.version = safeVersion;
+    this.lastUpdate = rawApiRow.lastUpdate;
+    this.firstReport = rawApiRow.firstReport;
+    this.lastReport = rawApiRow.lastReport;
+    this.size = Number(rawApiRow.size);
+    this.reportsPerDay = Number(safeReportsPerDay);
+    this.rejectedCount = Number(rawApiRow.rejectedCount);
+    this.retired = safeRetired;
+    this.fullDumps = safeFullDumps;
+
+    Object.freeze(this);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,8 +33,8 @@
       "@post": [
         "src/post/index"
       ],
-      "@symbols": [
-        "src/symbols/index"
+      "@versions": [
+        "src/versions/index"
       ],
       "@spec/*": [
         "spec/*"


### PR DESCRIPTION
Fixes #75

BREAKING CHANGE: we've merged the Symbols and Versions APIs to a single Versions API and thus have removed the Symbols API client.