### PR TITLE
feat: add support for debugId

### DIFF
--- a/src/common/file/bugsplat-file.ts
+++ b/src/common/file/bugsplat-file.ts
@@ -4,6 +4,8 @@ export class UploadableFile {
     constructor(
         public readonly name: string,
         public readonly size: number,
-        public readonly file: File | fs.ReadStream | Buffer
+        public readonly file: File | fs.ReadStream | Buffer,
+        public readonly lastModifiedDate?: Date,
+        public readonly debugId?: string
     ) { }
 }

--- a/src/versions/versions-api-client/versions-api-client.spec.ts
+++ b/src/versions/versions-api-client/versions-api-client.spec.ts
@@ -217,6 +217,27 @@ describe('VersionsApiClient', () => {
             expect(fakeFormData.append).toHaveBeenCalledWith('appVersion', version);
             expect(fakeFormData.append).toHaveBeenCalledWith('size', files[0].size.toString());
             expect(fakeFormData.append).toHaveBeenCalledWith('symFileName', path.basename(files[0].name));
+            expect(fakeFormData.append).not.toHaveBeenCalledWith('lastModifiedDate', jasmine.anything());
+            expect(fakeFormData.append).not.toHaveBeenCalledWith('dbgId', jasmine.anything());
+        });
+
+        it('should append dbgId and lastModifiedDate if provided', async () => {
+            files = [{
+                name: '📄.sym',
+                size: 1337,
+                debugId: 'abc123',
+                lastModifiedDate: new Date()
+            }];
+
+            await versionsApiClient.postSymbols(
+                database,
+                application,
+                version,
+                files
+            );
+
+            expect(fakeFormData.append).toHaveBeenCalledWith('lastModified', files[0].lastModifiedDate.toISOString());
+            expect(fakeFormData.append).toHaveBeenCalledWith('dbgId', files[0].debugId);
         });
 
         it('should call fetch with correct route', () => {

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -99,12 +99,16 @@ export class VersionsApiClient {
             .map(async (file) => {
                 const name = file.name;
                 const size = file.size;
+                const lastModifiedDate = file.lastModifiedDate;
+                const debugId = file.debugId;
                 const presignedUrl = await this.getPresignedUrl(
                     database,
                     application,
                     version,
                     size,
-                    name
+                    name,
+                    lastModifiedDate,
+                    debugId
                 );
     
                 const response = await this._s3ApiClient.uploadFileToPresignedUrl(presignedUrl, file);
@@ -121,7 +125,9 @@ export class VersionsApiClient {
         appName: string,
         appVersion: string,
         size: number,
-        symFileName: string
+        symFileName: string,
+        lastModifiedDate?: Date,
+        debugId?: string
     ): Promise<string> {
         const formData = this._client.createFormData();
         formData.append('database', database);
@@ -129,6 +135,14 @@ export class VersionsApiClient {
         formData.append('appVersion', appVersion);
         formData.append('size', size.toString());
         formData.append('symFileName', symFileName);
+
+        if (lastModifiedDate && debugId) {
+            formData.append('SendPdbsVersion', 'bsv1');
+            formData.append('moduleName', symFileName);
+            formData.append('lastModified', lastModifiedDate.toISOString());
+            formData.append('dbgId', debugId);
+        }
+
         const init = {
             method: 'POST',
             body: formData,


### PR DESCRIPTION
### Description

Extracts Debug ID from .sym files which is helpful for Electron apps with NAPI plugins.

### TODO
- [x] Add tests
- [ ] Figure out why Debug ID isn't setting the GUID column on the versions page

### Checklist

- [ ] Tested manually
- [ ] Unit tests pass with no errors or warnings
- [ ] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
