### PR TITLE
fix: better error for invalid client id or client secret

### DIFF
--- a/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
+++ b/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
@@ -33,7 +33,7 @@ describe('OAuthClientCredentialsClient', () => {
         );
         (<any>sut)._fetch.and.returnValues(
             Promise.resolve(fakeAuthorizeResponseBody),
-            Promise.resolve(fakeFetchResponseBody),
+            Promise.resolve(fakeFetchResponseBody)
         );
     });
 

--- a/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
+++ b/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
@@ -33,7 +33,7 @@ describe('OAuthClientCredentialsClient', () => {
         );
         (<any>sut)._fetch.and.returnValues(
             Promise.resolve(fakeAuthorizeResponseBody),
-            Promise.resolve(fakeFetchResponseBody)
+            Promise.resolve(fakeFetchResponseBody),
         );
     });
 
@@ -118,6 +118,8 @@ describe('OAuthClientCredentialsClient', () => {
         });
 
         it('should call fetch with new init if init is not provided', async () => {
+            (<any>sut)._fetch.and.returnValue(Promise.resolve(fakeAuthorizeResponseBody));
+
             await sut.fetch(route);
 
             const mostRecentCallArgs = (<any>sut)._fetch.calls.mostRecent().args;
@@ -129,6 +131,17 @@ describe('OAuthClientCredentialsClient', () => {
 
         it('should return result', () => {
             expect(result).toEqual(fakeFetchResponseBody);
+        });
+
+        describe('error', () => {
+            it('should throw error with useful message if fetch returns 401', async () => {
+                (<any>sut)._fetch.and.resolveTo(createFakeResponseBody(401));
+
+                await expectAsync(sut.fetch(route)).toBeRejectedWithError(
+                    Error,
+                    /Could not authenticate/
+                );
+            });
         });
     });
 });

--- a/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.ts
+++ b/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.ts
@@ -74,6 +74,12 @@ export class OAuthClientCredentialsClient implements ApiClient {
 
         init.headers['Authorization'] = `${this._tokenType} ${this._accessToken}`;
         
-        return this._fetch(url.href, init);
+        const response = await this._fetch(url.href, init);
+        
+        if (response.status === 401) {
+            throw new Error('Could not authenticate, check credentials and try again');
+        }
+
+        return response;
     }  
 }


### PR DESCRIPTION
The 401 case is a tricky one, you can have a valid token, but if it can't access the specific resource a 401 error happens late in the request chain. We want to catch 401 errors and give at least some sort of helpful error message.