### PR TITLE
fix: better messages for 4xx errors

### DIFF
--- a/src/common/client/s3-api-client/s3-api-client.spec.ts
+++ b/src/common/client/s3-api-client/s3-api-client.spec.ts
@@ -61,7 +61,7 @@ describe('S3ApiClient', () => {
                 const file = { name, size } as any;
                 (s3ApiClient as any)._fetch.and.resolveTo({ status: 500 });
 
-                await expectAsync(s3ApiClient.uploadFileToPresignedUrl(url, file)).toBeRejectedWithError(`Error uploading to presignedUrl ${url}`);
+                await expectAsync(s3ApiClient.uploadFileToPresignedUrl(url, file)).toBeRejectedWithError(`Error uploading to presigned URL ${url}`);
             });
         });
     });

--- a/src/common/client/s3-api-client/s3-api-client.ts
+++ b/src/common/client/s3-api-client/s3-api-client.ts
@@ -16,7 +16,7 @@ export class S3ApiClient {
         });
 
         if (response.status !== 200) {
-            throw new Error(`Error uploading to presignedUrl ${presignedUrl}`);
+            throw new Error(`Error uploading to presigned URL ${presignedUrl}`);
         }
 
         return response;

--- a/src/post/crash-post-client.e2e.ts
+++ b/src/post/crash-post-client.e2e.ts
@@ -1,8 +1,10 @@
 import { CrashPostClient, CrashType } from '@post';
 import { config } from '@spec/config';
 import { createUploadableFile } from '@spec/files/create-bugsplat-file';
+import { firstValueFrom, timer } from 'rxjs';
 
 describe('CrashPostClient', () => {
+    beforeEach(async () => firstValueFrom(timer(2000)));  // Prevent rate-limiting
     
     describe('postCrash', () => {
         it('should post crash to BugSplat and return 200', async () => {

--- a/src/post/crash-post-client.ts
+++ b/src/post/crash-post-client.ts
@@ -58,7 +58,7 @@ export class CrashPostClient {
             + `&crashPostSize=${size}`;
         const response = await this._processorApiClient.fetch(route);
         if (response.status === 429) {
-            throw new Error("Failed to get crash upload URL, too many requests")
+            throw new Error('Failed to get crash upload URL, too many requests');
         }
 
         if (response.status !== 200) {

--- a/src/post/crash-post-client.ts
+++ b/src/post/crash-post-client.ts
@@ -57,8 +57,12 @@ export class CrashPostClient {
             + `&appVersion=${version}`
             + `&crashPostSize=${size}`;
         const response = await this._processorApiClient.fetch(route);
+        if (response.status === 429) {
+            throw new Error("Failed to get crash upload URL, too many requests")
+        }
+
         if (response.status !== 200) {
-            throw new Error('Failed to get crash upload url!');
+            throw new Error('Failed to get crash upload URL');
         }
 
         const json = await response.json();

--- a/src/versions/versions-api-client/versions-api-client.spec.ts
+++ b/src/versions/versions-api-client/versions-api-client.spec.ts
@@ -252,7 +252,19 @@ describe('VersionsApiClient', () => {
         });
 
         describe('error', () => {
-            it('should throw if response status is not 200', async () => {
+            it('should throw if error with invalid credentials message if status is 403', async () => {
+                const fakeErrorResponse = createFakeResponseBody(403);
+                fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
+
+                await expectAsync(versionsApiClient.postSymbols(
+                    database,
+                    application,
+                    version,
+                    files
+                )).toBeRejectedWithError('Error getting presigned URL, invalid credentials');
+            });
+            
+            it('should throw if response status is not 200, or 403', async () => {
                 const fakeErrorResponse = createFakeResponseBody(400);
                 fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
 
@@ -261,7 +273,7 @@ describe('VersionsApiClient', () => {
                     application,
                     version,
                     files
-                )).toBeRejectedWithError(`Error getting presignedUrl for ${files[0].name}`);
+                )).toBeRejectedWithError(`Error getting presigned URL for ${files[0].name}`);
             });
 
             it('should throw if response json Status is \'Failed\'', async () => {

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -138,6 +138,10 @@ export class VersionsApiClient {
         };
 
         const response = await this._client.fetch(this.route, <RequestInit><unknown>init);
+        if (response.status === 429) {
+            throw new Error('Error getting presigned URL, too many requests');
+        }
+
         if (response.status === 403) {
             throw new Error('Error getting presigned URL, invalid credentials');
         }

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -138,8 +138,12 @@ export class VersionsApiClient {
         };
 
         const response = await this._client.fetch(this.route, <RequestInit><unknown>init);
+        if (response.status === 403) {
+            throw new Error('Error getting presigned URL, invalid credentials');
+        }
+
         if (response.status !== 200) {
-            throw new Error(`Error getting presignedUrl for ${symFileName}`);
+            throw new Error(`Error getting presigned URL for ${symFileName}`);
         }
 
         const json = await response.json();


### PR DESCRIPTION
Stumbled across this when trying to get pulse working against Octomore.