### PR TITLE
feat: add processor field to crash upload

### DIFF
--- a/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
+++ b/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
@@ -1,8 +1,8 @@
 import { createFakeFormData } from '@spec/fakes/common/form-data';
 import { createFakeResponseBody, FakeResponseBody } from '@spec/fakes/common/response';
-import { BugSplatResponse } from 'dist/esm';
-import { OAuthLoginResponse } from 'dist/esm/common/client/oauth-client-credentials-api-client/oauth-login-response';
 import { OAuthClientCredentialsClient } from './oauth-client-credentials-api-client';
+import { BugSplatResponse } from '@common';
+import { OAuthLoginResponse } from './oauth-login-response';
 
 describe('OAuthClientCredentialsClient', () => {
     let clientId: string;

--- a/src/crash/crash-api-client/crash-api-client.spec.ts
+++ b/src/crash/crash-api-client/crash-api-client.spec.ts
@@ -94,6 +94,7 @@ describe('CrashApiClient', () => {
         let fakeReprocessApiResponse;
         let fakeBugSplatApiClient;
         let result;
+        const processor = 'Oban-127.0.0.1';
 
         beforeEach(async () => {
             fakeReprocessApiResponse = { success: true };
@@ -108,10 +109,17 @@ describe('CrashApiClient', () => {
             expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith('/api/crash/reprocess', jasmine.anything());
         });
 
+        it('should call form data append with processor if provided', async () => {
+            await client.reprocessCrash(database, id, true, processor);
+
+            expect(fakeFormData.append).toHaveBeenCalledWith('processor', processor);
+        });
+
         it('should call fetch with formData containing database, id and force', () => {
             expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
             expect(fakeFormData.append).toHaveBeenCalledWith('id', id.toString());
             expect(fakeFormData.append).toHaveBeenCalledWith('force', 'true');
+            expect(fakeFormData.append).not.toHaveBeenCalledWith('processor', processor);
             expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith(
                 jasmine.any(String),
                 jasmine.objectContaining({

--- a/src/crash/crash-api-client/crash-api-client.ts
+++ b/src/crash/crash-api-client/crash-api-client.ts
@@ -36,7 +36,7 @@ export class CrashApiClient {
         return createCrashDetails(json as CrashDetailsRawResponse);
     }
 
-    async reprocessCrash(database: string, crashId: number, force = false, processor = ""): Promise<SuccessResponse> {
+    async reprocessCrash(database: string, crashId: number, force = false, processor = ''): Promise<SuccessResponse> {
         ac.assertNonWhiteSpaceString(database, 'database');
         ac.assertBoolean(force, 'force');
         if (crashId <= 0) {

--- a/src/crash/crash-api-client/crash-api-client.ts
+++ b/src/crash/crash-api-client/crash-api-client.ts
@@ -47,7 +47,7 @@ export class CrashApiClient {
         formData.append('database', database);
         formData.append('id', crashId.toString());
         formData.append('force', force.toString());
-        if( processor.length > 0 ) {
+        if (processor) {
             formData.append('processor', processor);
         }
         const init = {

--- a/src/crash/crash-api-client/crash-api-client.ts
+++ b/src/crash/crash-api-client/crash-api-client.ts
@@ -36,7 +36,7 @@ export class CrashApiClient {
         return createCrashDetails(json as CrashDetailsRawResponse);
     }
 
-    async reprocessCrash(database: string, crashId: number, force = false): Promise<SuccessResponse> {
+    async reprocessCrash(database: string, crashId: number, force = false, processor = ""): Promise<SuccessResponse> {
         ac.assertNonWhiteSpaceString(database, 'database');
         ac.assertBoolean(force, 'force');
         if (crashId <= 0) {
@@ -47,6 +47,9 @@ export class CrashApiClient {
         formData.append('database', database);
         formData.append('id', crashId.toString());
         formData.append('force', force.toString());
+        if( processor.length > 0 ) {
+            formData.append('processor', processor);
+        }
         const init = {
             method: 'POST',
             body: formData,


### PR DESCRIPTION
### Description

Adds an optional reprocess parameter that forces the reprocess to run on a specific crash analyzer. 

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
