### PR TITLE
feat!: s3 symserv upload support

### DIFF
--- a/spec/fakes/common/bugsplat-api-client.ts
+++ b/spec/fakes/common/bugsplat-api-client.ts
@@ -1,7 +1,9 @@
+import { ApiClient } from '@common';
+
 export function createFakeBugSplatApiClient(
     formData: FormData,
     response: any
-): any {
+): jasmine.SpyObj<ApiClient> {
     const fakeBugSplatApiClient = jasmine.createSpyObj('BugSplatApiClient', [
         'createFormData',
         'fetch'

--- a/spec/files/create-bugsplat-file.ts
+++ b/spec/files/create-bugsplat-file.ts
@@ -1,9 +1,11 @@
 import { UploadableFile } from '@common';
-import fs, { statSync } from 'fs';
+import { createReadStream, ReadStream } from 'fs';
+import { stat } from 'fs/promises';
 import path from 'path';
 
-export function createUploadableFile(filePath: string): UploadableFile {
-    const fileSize = statSync(filePath).size;
+export async function createUploadableFile(filePath: string): Promise<UploadableFile> {
+    const fileSize = await stat(filePath).then(stats => stats.size);
     const fileName = path.basename(filePath);
-    return new UploadableFile(fileName, fileSize, fs.createReadStream(filePath));
+    const readableStream = ReadStream.toWeb(createReadStream(filePath));
+    return new UploadableFile(fileName, fileSize, readableStream);
 }

--- a/spec/files/create-bugsplat-file.ts
+++ b/spec/files/create-bugsplat-file.ts
@@ -1,11 +1,11 @@
 import { UploadableFile } from '@common';
-import { createReadStream, ReadStream } from 'fs';
-import { stat } from 'fs/promises';
-import path from 'path';
+import { createReadStream, ReadStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { basename } from 'node:path';
 
 export async function createUploadableFile(filePath: string): Promise<UploadableFile> {
     const fileSize = await stat(filePath).then(stats => stats.size);
-    const fileName = path.basename(filePath);
+    const fileName = basename(filePath);
     const readableStream = ReadStream.toWeb(createReadStream(filePath));
     return new UploadableFile(fileName, fileSize, readableStream);
 }

--- a/spec/files/create-symbol-file.ts
+++ b/spec/files/create-symbol-file.ts
@@ -1,0 +1,12 @@
+import { SymbolFile } from '@common';
+import { stat } from 'node:fs/promises';
+import { createUploadableFile } from './create-bugsplat-file';
+
+export async function createSymbolFile(path: string): Promise<SymbolFile> {
+    const uploadableFile = await createUploadableFile(path);
+    const uncompressedSize = await stat(path).then(stats => stats.size);
+    return {
+        ...uploadableFile,
+        uncompressedSize
+    };
+}

--- a/spec/files/native/post-native-crash.ts
+++ b/spec/files/native/post-native-crash.ts
@@ -12,8 +12,8 @@ export async function postNativeCrashAndSymbols(
     application: string,
     version: string
 ): Promise<PostCrashResponse> {
-    const exeFile = createUploadableFile('./spec/files/native/myConsoleCrasher.exe');
-    const pdbFile = createUploadableFile('./spec/files/native/myConsoleCrasher.pdb');
+    const exeFile = await createUploadableFile('./spec/files/native/myConsoleCrasher.exe');
+    const pdbFile = await createUploadableFile('./spec/files/native/myConsoleCrasher.pdb');
     const files = [exeFile, pdbFile];
     const symbolsApiClient = new VersionsApiClient(authenticatedClient);
     await symbolsApiClient.postSymbols(
@@ -31,7 +31,7 @@ export async function postNativeCrash(
     application: string,
     version: string
 ): Promise<PostCrashResponse> {
-    const crashFile = createUploadableFile('./spec/files/native/myConsoleCrasher.zip');
+    const crashFile = await createUploadableFile('./spec/files/native/myConsoleCrasher.zip');
     const crashPostClient = new CrashPostClient(database);
     await firstValueFrom(timer(2000)); // Prevent rate-limiting
     const postCrashResult = await crashPostClient.postCrash(

--- a/spec/files/native/post-native-crash.ts
+++ b/spec/files/native/post-native-crash.ts
@@ -5,6 +5,7 @@ import { VersionsApiClient } from '@versions';
 import { firstValueFrom, timer } from 'rxjs';
 import { PostCrashResponse } from 'src/post/post-crash-response';
 import { createUploadableFile } from '../create-bugsplat-file';
+import { createSymbolFile } from '../create-symbol-file';
 
 export async function postNativeCrashAndSymbols(
     authenticatedClient: BugSplatApiClient,
@@ -12,8 +13,8 @@ export async function postNativeCrashAndSymbols(
     application: string,
     version: string
 ): Promise<PostCrashResponse> {
-    const exeFile = await createUploadableFile('./spec/files/native/myConsoleCrasher.exe');
-    const pdbFile = await createUploadableFile('./spec/files/native/myConsoleCrasher.pdb');
+    const exeFile = await createSymbolFile('./spec/files/native/myConsoleCrasher.exe');
+    const pdbFile = await createSymbolFile('./spec/files/native/myConsoleCrasher.pdb');
     const files = [exeFile, pdbFile];
     const symbolsApiClient = new VersionsApiClient(authenticatedClient);
     await symbolsApiClient.postSymbols(

--- a/src/common/file/bugsplat-file.ts
+++ b/src/common/file/bugsplat-file.ts
@@ -1,9 +1,9 @@
-import type fs from 'fs';
+import type { ReadableStream } from 'node:stream/web';
 
 export class UploadableFile {
     constructor(
         public readonly name: string,
         public readonly size: number,
-        public readonly file: File | fs.ReadStream | Buffer
+        public readonly file: File | Buffer | ReadableStream
     ) { }
 }

--- a/src/common/file/index.ts
+++ b/src/common/file/index.ts
@@ -1,0 +1,2 @@
+export { UploadableFile } from './bugsplat-file';
+export { GZippedSymbolFile, SymbolFile } from './symbol-file';

--- a/src/common/file/symbol-file.ts
+++ b/src/common/file/symbol-file.ts
@@ -1,5 +1,5 @@
 import { UploadableFile } from '@common';
 import type { ReadableStream } from 'node:stream/web';
 
-export type SymbolFile = UploadableFile & { dbgId?: string, lastModified?: Date, moduleName?: string };
-export type GZippedSymbolFile = Omit<Required<SymbolFile>, 'file'> &  { file: ReadableStream, uncompressedSize: number };
+export type SymbolFile = UploadableFile & { dbgId?: string, lastModified?: Date, moduleName?: string, uncompressedSize: number };
+export type GZippedSymbolFile = Omit<Required<SymbolFile>, 'file'> &  { file: ReadableStream };

--- a/src/common/file/symbol-file.ts
+++ b/src/common/file/symbol-file.ts
@@ -1,0 +1,5 @@
+import { UploadableFile } from '@common';
+import type { ReadableStream } from 'node:stream/web';
+
+export type SymbolFile = UploadableFile & { dbgId?: string, lastModified?: Date, moduleName?: string };
+export type GZippedSymbolFile = Omit<Required<SymbolFile>, 'file'> &  { file: ReadableStream, uncompressedSize: number };

--- a/src/common/index.ts
+++ b/src/common/index.ts
@@ -1,5 +1,6 @@
 export * from './client';
 export * from './data';
-export { bugsplatAppHostUrl } from './host';
-export { UploadableFile } from './file/bugsplat-file';
 export { Environment } from './environment';
+export * from './file';
+export { bugsplatAppHostUrl } from './host';
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,4 @@ export * from './events';
 export * from './post';
 export * from './summary';
 export * from './versions';
+export * from './symbols';

--- a/src/post/crash-post-client.e2e.ts
+++ b/src/post/crash-post-client.e2e.ts
@@ -11,7 +11,7 @@ describe('CrashPostClient', () => {
             const application = 'myConsoleCrasher';
             const version = `${Math.random() * 1000000}`;
             const md5 = 'ebe24c1cd1a0912904658fa4fad2b539';
-            const crashFile = createUploadableFile('spec/files/native/myConsoleCrasher.zip');
+            const crashFile = await createUploadableFile('spec/files/native/myConsoleCrasher.zip');
             const crashPostClient = new CrashPostClient(config.database);
             const result = await crashPostClient.postCrash(
                 application,

--- a/src/post/crash-post-client.ts
+++ b/src/post/crash-post-client.ts
@@ -5,7 +5,7 @@ import { PostCrashResponse } from './post-crash-response';
 export class CrashPostClient {
 
     private _processorApiClient: BugSplatApiClient;
-    private _s3ApiClient: S3ApiClient;
+    private _s3ApiClient = new S3ApiClient();
 
     constructor(
         private _database: string,
@@ -16,7 +16,6 @@ export class CrashPostClient {
             `https://${this._database}.bugsplat.com`,
             this._environment
         );
-        this._s3ApiClient = new S3ApiClient();
     }
 
     async postCrash(

--- a/src/symbols/index.ts
+++ b/src/symbols/index.ts
@@ -1,0 +1,1 @@
+export { SymbolsApiClient } from './symbols-api-client/symbols-api-client';

--- a/src/symbols/symbols-api-client/symbols-api-client.e2e.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.e2e.ts
@@ -1,0 +1,69 @@
+import { BugSplatApiClient } from '@common';
+import { config } from '@spec/config';
+import { SymbolsApiClient } from '@symbols';
+import { ReadStream, createReadStream, createWriteStream } from 'node:fs';
+import { stat } from 'node:fs/promises';
+import { basename } from 'node:path';
+import { pipeline } from 'node:stream/promises';
+import { createGzip } from 'node:zlib';
+
+describe('SymbolsApiClient', () => {
+    let client: SymbolsApiClient;
+    let database;
+    let application;
+    let version = '1.0.0';
+
+    beforeEach(async () => {
+        database = config.database;
+        application = 'bugsplat-js-api-client';
+        version = `${Math.random() * 1000000}`;
+
+        const bugsplat = await BugSplatApiClient.createAuthenticatedClientForNode(
+            config.email,
+            config.password,
+            config.host
+        );
+
+        client = new SymbolsApiClient(bugsplat);
+    });
+
+    describe('postSymbols', () => {
+        it('should return 200 for post with valid database, application, version and files', async () => {
+            const filePath = './spec/files/native/myConsoleCrasher.pdb';
+            const moduleName = 'myConsoleCrasher.pdb';
+            const dbgId = '2CA6992CEA8847A8B821730F6F5D20321';
+            const name = basename(filePath);
+            const stats = await stat(filePath);
+            const uncompressedSize = stats.size;
+            const lastModified = stats.mtime;
+
+            const gzipFilePath = `${filePath}.gz`;
+
+            await pipeline(
+                createReadStream(filePath),
+                createGzip(),
+                createWriteStream(gzipFilePath)
+            );
+
+            const size = await stat(gzipFilePath).then(stats => stats.size);
+            const file = ReadStream.toWeb(createReadStream(gzipFilePath));
+            const gzippedSymbolFile = {
+                name,
+                size,
+                uncompressedSize,
+                dbgId,
+                file,
+                moduleName,
+                lastModified
+            };
+            const response = await client.postSymbols(
+                database,
+                application,
+                version,
+                [gzippedSymbolFile]
+            );
+
+            expect(response[0].status).toEqual(200);
+        });
+    });
+});

--- a/src/symbols/symbols-api-client/symbols-api-client.spec.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.spec.ts
@@ -1,0 +1,121 @@
+import { SymbolsApiClient } from './symbols-api-client';
+
+describe('SymbolsApiClient', () => {
+    const database = 'fred';
+    const application = 'my-js-crasher';
+    const version = '1.0.0';
+    const url = 'https://newayz.net';
+    let fakeFormData;
+    let fakeBugSplatApiClient;
+    let fakeSuccessResponse;
+    let fakeS3ApiClient;
+
+    let symbolsApiClient: SymbolsApiClient;
+
+    beforeEach(() => {
+        // TODO BG
+    });
+
+    describe('postSymbols', () => {
+        // TODO BG
+        // let files;
+        // let result;
+        // let timer;
+
+        // beforeEach(async () => {
+        //     files = [{
+        //         name: '📄.sym',
+        //         size: 1337
+        //     }];
+        //     timer = jasmine.createSpy();
+        //     timer.and.returnValue(of(0));
+        //     (<any>versionsApiClient)._timer = timer;
+
+        //     result = await versionsApiClient.postSymbols(
+        //         database,
+        //         application,
+        //         version,
+        //         files
+        //     );
+        // });
+
+        // it('should append dbName, appName, appVersion, size and symFileName to FormData', () => {
+        //     expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
+        //     expect(fakeFormData.append).toHaveBeenCalledWith('appName', application);
+        //     expect(fakeFormData.append).toHaveBeenCalledWith('appVersion', version);
+        //     expect(fakeFormData.append).toHaveBeenCalledWith('size', files[0].size.toString());
+        //     expect(fakeFormData.append).toHaveBeenCalledWith('symFileName', path.basename(files[0].name));
+        // });
+
+        // it('should call fetch with correct route', () => {
+        //     expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith(
+        //         '/api/versions',
+        //         jasmine.anything()
+        //     );
+        // });
+
+        // it('should call fetch with method POST, formData and include credentials', () => {
+        //     expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith(
+        //         jasmine.anything(),
+        //         jasmine.objectContaining({
+        //             method: 'POST',
+        //             credentials: 'include',
+        //             body: fakeFormData
+        //         })
+        //     );
+        // });
+
+        // it('should call uploadFileToPresignedUrl with url, and file', () => {
+        //     expect(fakeS3ApiClient.uploadFileToPresignedUrl).toHaveBeenCalledWith(url, files[0]);
+        // });
+
+        // it('should sleep between requests', () => {
+        //     expect((<any>versionsApiClient)._timer).toHaveBeenCalledWith(1000);
+        // });
+
+        // it('should return response', () => {
+        //     expect(result).toEqual(
+        //         jasmine.arrayContaining([fakeSuccessResponse])
+        //     );
+        // });
+
+        // describe('error', () => {
+        //     it('should throw if error with invalid credentials message if status is 403', async () => {
+        //         const fakeErrorResponse = createFakeResponseBody(403);
+        //         fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
+
+        //         await expectAsync(versionsApiClient.postSymbols(
+        //             database,
+        //             application,
+        //             version,
+        //             files
+        //         )).toBeRejectedWithError('Error getting presigned URL, invalid credentials');
+        //     });
+            
+        //     it('should throw if response status is not 200, or 403', async () => {
+        //         const fakeErrorResponse = createFakeResponseBody(400);
+        //         fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
+
+        //         await expectAsync(versionsApiClient.postSymbols(
+        //             database,
+        //             application,
+        //             version,
+        //             files
+        //         )).toBeRejectedWithError(`Error getting presigned URL for ${files[0].name}`);
+        //     });
+
+        //     it('should throw if response json Status is \'Failed\'', async () => {
+        //         const message = '🥱';
+        //         const fakeErrorResponse = createFakeResponseBody(200, { Status: 'Failed', Error: message });
+        //         fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
+
+        //         await expectAsync(versionsApiClient.postSymbols(
+        //             database,
+        //             application,
+        //             version,
+        //             files
+        //         )).toBeRejectedWithError(message);
+        //     });
+        // });
+    });
+});

--- a/src/symbols/symbols-api-client/symbols-api-client.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.ts
@@ -1,0 +1,155 @@
+import { ApiClient, BugSplatResponse, GZippedSymbolFile, S3ApiClient } from '@common';
+import { lastValueFrom, timer } from 'rxjs';
+
+// const gzipMagic = '1f 8b';
+
+export class SymbolsApiClient {
+
+    private readonly uploadUrl = '/symsrv/uploadUrl';
+    private readonly uploadCompleteUrl = '/symsrv/uploadComplete';
+
+    private _s3ApiClient: S3ApiClient;
+    private _timer = timer;
+
+    constructor(private _client: ApiClient) {
+        this._s3ApiClient = new S3ApiClient();
+    }
+
+    async postSymbols(
+        database: string,
+        application: string,
+        version: string,
+        files: Array<GZippedSymbolFile> 
+    ): Promise<Array<BugSplatResponse>> {
+        const promises = files
+            .map(async (file) => {
+                const [checkStream, untouchedStream] = file.file.tee();
+                const { value, done } = await checkStream.getReader().read();
+
+                if (done) {
+                    throw new Error('Could not read symbol file stream');
+                }
+
+                if (!this.isGzipMagicBytes(value)) {
+                    throw new Error('Symbol file stream does not start with gzip magic bytes');
+                }
+
+                file.file = untouchedStream;
+                const presignedUrl = await this.getPresignedUrl(
+                    database,
+                    application,
+                    version,
+                    file
+                );
+    
+                const uploadResponse = await this._s3ApiClient.uploadFileToPresignedUrl(presignedUrl, file);
+                
+                const completeResponse = await this.postUploadComplete(
+                    database,
+                    application,
+                    version,
+                    file
+                );
+                
+                await lastValueFrom(this._timer(1000));
+
+                return uploadResponse;
+            });
+    
+        return Promise.all(promises);
+    }
+
+    private async getPresignedUrl(
+        database: string,
+        appName: string,
+        appVersion: string,
+        file: GZippedSymbolFile
+    ): Promise<string> {
+        const formData = this._client.createFormData();
+        formData.append('database', database);
+        formData.append('appName', appName);
+        formData.append('appVersion', appVersion);
+        formData.append('size', `${file.uncompressedSize}`);
+        formData.append('symFileName', file.name);
+        formData.append('moduleName', file.moduleName);
+        formData.append('dbgId', file.dbgId);
+        formData.append('lastModified', `${file.lastModified}`);
+        formData.append('SendPdbsVersion', 'spdbsv2');
+
+        const request = {
+            method: 'POST',
+            body: formData,
+            cache: 'no-cache',
+            credentials: 'include',
+            redirect: 'follow',
+            duplex: 'half'
+        } as RequestInit;
+
+        const response = await this._client.fetch(this.uploadUrl, request);
+        if (response.status === 429) {
+            throw new Error('Error getting presigned URL, too many requests');
+        }
+
+        if (response.status === 403) {
+            throw new Error('Error getting presigned URL, invalid credentials');
+        }
+
+        if (response.status !== 200) {
+            throw new Error(`Error getting presigned URL for ${file.name}`);
+        }
+
+        const json = await response.json() as Response & { url?: string };
+        if (json.Status === 'Failed') {
+            throw new Error(json.Error);
+        }
+
+        return json.url as string;
+    }
+
+    private async postUploadComplete(
+        database: string,
+        appName: string,
+        appVersion: string,
+        file: GZippedSymbolFile
+    ): Promise<BugSplatResponse> {
+        const formData = this._client.createFormData();
+        formData.append('database', database);
+        formData.append('appName', appName);
+        formData.append('appVersion', appVersion);
+        formData.append('size', `${file.uncompressedSize}`);
+        formData.append('symFileName', file.name);
+        formData.append('moduleName', file.moduleName);
+        formData.append('dbgId', file.dbgId);
+        formData.append('lastModified', `${file.lastModified}`);
+        formData.append('SendPdbsVersion', 'spdbsv2');
+
+        const request = {
+            method: 'POST',
+            body: formData,
+            cache: 'no-cache',
+            credentials: 'include',
+            redirect: 'follow',
+            duplex: 'half'
+        } as RequestInit;
+
+        const response = await this._client.fetch(this.uploadCompleteUrl, request);
+
+        if (response.status !== 200) {
+            throw new Error(`Error completing symbol upload for ${file.name}, status ${response.status}`);
+        }
+
+        const json = await response.json() as Response & { url?: string };
+        if (json.Status === 'Failed') {
+            throw new Error(json.Error);
+        }
+
+        return response;
+    }
+
+    private isGzipMagicBytes(buffer: Buffer) {
+        const view = new Uint8Array(buffer);
+        return view[0] === 0x1f && view[1] === 0x8b;
+    }
+}
+
+type Response = { Status: string, Error?: string };

--- a/src/symbols/symbols-api-client/symbols-api-client.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.ts
@@ -9,6 +9,8 @@ export class SymbolsApiClient {
 
     constructor(private _client: ApiClient) { }
 
+    // Gzip implementation is different in node.js vs browser
+    // Consumer must gzip files before calling this method
     async postSymbols(
         database: string,
         application: string,

--- a/src/versions/index.ts
+++ b/src/versions/index.ts
@@ -1,3 +1,2 @@
 export { VersionsApiClient } from './versions-api-client/versions-api-client';
 export { VersionsApiRow } from './versions-api-row/versions-api-row';
-export { SymbolFile } from './versions-api-client/symbol-file';

--- a/src/versions/versions-api-client/symbol-file.ts
+++ b/src/versions/versions-api-client/symbol-file.ts
@@ -1,3 +1,0 @@
-import { UploadableFile } from '@common';
-
-export type SymbolFile = UploadableFile & { dbgId?: string, lastModified?: Date, moduleName?: string }

--- a/src/versions/versions-api-client/versions-api-client.e2e.ts
+++ b/src/versions/versions-api-client/versions-api-client.e2e.ts
@@ -1,5 +1,6 @@
 import { BugSplatApiClient, UploadableFile } from '@common';
 import { config } from '@spec/config';
+import { createSymbolFile } from '@spec/files/create-symbol-file';
 import { postNativeCrashAndSymbols } from '@spec/files/native/post-native-crash';
 import { VersionsApiClient } from '@versions';
 import { createReadStream, ReadStream, statSync } from 'node:fs';
@@ -100,10 +101,7 @@ describe('VersionsApiClient', () => {
     describe('postSymbols', () => {
         it('should return 200 for post with valid database, application, version and files', async () => {
             const filePath = './spec/files/js/index.js.map';
-            const name = basename(filePath);
-            const size = statSync(filePath).size;
-            const readableStream = ReadStream.toWeb(createReadStream(filePath));
-            const file = new UploadableFile(name, size, readableStream);
+            const file = await createSymbolFile(filePath);
             const response = await client.postSymbols(
                 database,
                 application,

--- a/src/versions/versions-api-client/versions-api-client.e2e.ts
+++ b/src/versions/versions-api-client/versions-api-client.e2e.ts
@@ -2,7 +2,7 @@ import { BugSplatApiClient, UploadableFile } from '@common';
 import { config } from '@spec/config';
 import { postNativeCrashAndSymbols } from '@spec/files/native/post-native-crash';
 import { VersionsApiClient } from '@versions';
-import fs from 'fs';
+import fs, { ReadStream } from 'fs';
 import path from 'path';
 
 describe('VersionsApiClient', () => {
@@ -102,7 +102,8 @@ describe('VersionsApiClient', () => {
             const filePath = './spec/files/js/index.js.map';
             const name = path.basename(filePath);
             const size = fs.statSync(filePath).size;
-            const file = new UploadableFile(name, size, fs.createReadStream(filePath));
+            const readableStream = ReadStream.toWeb(fs.createReadStream(filePath));
+            const file = new UploadableFile(name, size, readableStream);
             const response = await client.postSymbols(
                 database,
                 application,

--- a/src/versions/versions-api-client/versions-api-client.e2e.ts
+++ b/src/versions/versions-api-client/versions-api-client.e2e.ts
@@ -2,8 +2,8 @@ import { BugSplatApiClient, UploadableFile } from '@common';
 import { config } from '@spec/config';
 import { postNativeCrashAndSymbols } from '@spec/files/native/post-native-crash';
 import { VersionsApiClient } from '@versions';
-import fs, { ReadStream } from 'fs';
-import path from 'path';
+import { createReadStream, ReadStream, statSync } from 'node:fs';
+import { basename } from 'node:path';
 
 describe('VersionsApiClient', () => {
     let client: VersionsApiClient;
@@ -100,9 +100,9 @@ describe('VersionsApiClient', () => {
     describe('postSymbols', () => {
         it('should return 200 for post with valid database, application, version and files', async () => {
             const filePath = './spec/files/js/index.js.map';
-            const name = path.basename(filePath);
-            const size = fs.statSync(filePath).size;
-            const readableStream = ReadStream.toWeb(fs.createReadStream(filePath));
+            const name = basename(filePath);
+            const size = statSync(filePath).size;
+            const readableStream = ReadStream.toWeb(createReadStream(filePath));
             const file = new UploadableFile(name, size, readableStream);
             const response = await client.postSymbols(
                 database,

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -7,12 +7,11 @@ export class VersionsApiClient {
 
     private readonly route = '/api/versions';
 
-    private _s3ApiClient: S3ApiClient;
+    private _s3ApiClient = new S3ApiClient()
     private _tableDataClient: TableDataClient;
     private _timer = timer;
 
     constructor(private _client: ApiClient) {
-        this._s3ApiClient = new S3ApiClient();
         this._tableDataClient = new TableDataClient(this._client, this.route);
     }
 

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -1,8 +1,7 @@
-import { ApiClient, BugSplatResponse, S3ApiClient, TableDataClient, TableDataRequest, TableDataResponse } from '@common';
+import { ApiClient, BugSplatResponse, S3ApiClient, SymbolFile, TableDataClient, TableDataRequest, TableDataResponse } from '@common';
 import { lastValueFrom, timer } from 'rxjs';
 import { VersionsApiResponseRow, VersionsApiRow } from '../versions-api-row/versions-api-row';
 import { PutRetiredResponse } from './put-retired-response';
-import { SymbolFile } from './symbol-file';
 
 export class VersionsApiClient {
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,9 @@
       "@post": [
         "src/post/index"
       ],
+      "@symbols": [
+        "src/symbols/index"
+      ],
       "@versions": [
         "src/versions/index"
       ],


### PR DESCRIPTION
Adds support for uploading gzipped stream of guid identified symbol file to s3. The consumer is responsible for gzipping the file, but we check to ensure it's gzipped by peeking at the magic bytes at the beginning of the stream. Consumers can use [zlib.createGzip](https://nodejs.org/api/zlib.html#zlibcreategzipoptions) in Node.js, and [new CompressionStream('gzip')](https://developer.mozilla.org/en-US/docs/Web/API/Compression_Streams_API) in browsers. 

BREAKING CHANGE: drop support for `fs.ReadableStream` as it's not browser-compatible, use `ReadStream.toWeb(...)` to convert to web-compatible `ReadableStream`.