### PR TITLE
fix: gzip upload headers

### DIFF
--- a/src/common/client/s3-api-client/s3-api-client.spec.ts
+++ b/src/common/client/s3-api-client/s3-api-client.spec.ts
@@ -42,6 +42,29 @@ describe('S3ApiClient', () => {
             );
         });
 
+        it('should call fetch with additionalHeaders', async () => {
+            const url = 'https://bugsplat.com';
+            const name = '🐛.txt';
+            const size = 1337;
+            const file = { name, size, file: name } as any;
+            const additionalHeaders = { 'content-encoding': 'gzip' };
+
+            await s3ApiClient.uploadFileToPresignedUrl(url, file, additionalHeaders);
+
+            expect((s3ApiClient as any)._fetch).toHaveBeenCalledWith(
+                jasmine.anything(),
+                jasmine.objectContaining({
+                    method: 'PUT',
+                    headers: {
+                        'content-type': 'application/octet-stream',
+                        'content-length': `${size}`,
+                        ...additionalHeaders
+                    },
+                    body: file.file
+                })
+            );
+        });
+
         it('should return response', async () => {
             const url = 'https://bugsplat.com';
             const name = '🐛.txt';

--- a/src/common/client/s3-api-client/s3-api-client.ts
+++ b/src/common/client/s3-api-client/s3-api-client.ts
@@ -4,12 +4,13 @@ export class S3ApiClient {
 
     private _fetch = globalThis.fetch;
 
-    async uploadFileToPresignedUrl(presignedUrl: string, file: UploadableFile): Promise<Response> {
+    async uploadFileToPresignedUrl(presignedUrl: string, file: UploadableFile, additionalHeaders: HeadersInit = {}): Promise<Response> {
         const response = await this._fetch(presignedUrl, {
             method: 'PUT',
             headers: {
                 'content-type': 'application/octet-stream',
-                'content-length': `${file.size}`
+                'content-length': `${file.size}`,
+                ...additionalHeaders
             },
             body: file.file as BodyInit,
             duplex: 'half'

--- a/src/symbols/symbols-api-client/symbols-api-client.spec.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.spec.ts
@@ -84,6 +84,9 @@ describe('SymbolsApiClient', () => {
                 url,
                 jasmine.objectContaining({
                     file: fakeUntouchedStream
+                }),
+                jasmine.objectContaining({
+                    'content-encoding': 'gzip'
                 })
             );
         });

--- a/src/symbols/symbols-api-client/symbols-api-client.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.ts
@@ -37,8 +37,11 @@ export class SymbolsApiClient {
                     version,
                     file
                 );
+                const additionalHeaders = {
+                    'content-encoding': 'gzip'
+                };
     
-                const uploadResponse = await this._s3ApiClient.uploadFileToPresignedUrl(presignedUrl, file);
+                const uploadResponse = await this._s3ApiClient.uploadFileToPresignedUrl(presignedUrl, file, additionalHeaders);
                 
                 await this.postUploadComplete(
                     database,


### PR DESCRIPTION
### Description

Add content-encoding: gzip to upload header per request from @daveplunkett for s3 symsrv.

### Checklist

- [ ] Tested manually
- [ ] Unit tests pass with no errors or warnings
- [ ] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
