### PR TITLE
fix: don't treat zip files as windows symbols

### DIFF
--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -149,11 +149,16 @@ export class VersionsApiClient {
         formData.append('size', `${file.size}`);
         formData.append('symFileName', file.name);
 
-        if (file.dbgId && file.lastModified && file.moduleName) {
-            formData.append('moduleName', file.moduleName);
+        if (file.dbgId) {
             formData.append('dbgId', file.dbgId);
+        }
+
+        if (file.lastModified) {
             formData.append('lastModified', `${file.lastModified}`);
-            formData.append('SendPdbsVersion', 'bsv1');
+        }
+
+        if (file.moduleName) {
+            formData.append('moduleName', file.moduleName);
         }
 
         const request = {


### PR DESCRIPTION
Blocked by https://github.com/BugSplat-Git/webroot/pull/1048

Abandon the bsv1 protocol so that .zip files get treated as `Unknown` instead of `Windows`.

Fixes #114 