### PR TITLE
fix: post with crashTypeId

### DIFF
--- a/src/post/crash-post-client.spec.ts
+++ b/src/post/crash-post-client.spec.ts
@@ -76,7 +76,8 @@ describe('CrashPostClient', () => {
             expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
             expect(fakeFormData.append).toHaveBeenCalledWith('appName', application);
             expect(fakeFormData.append).toHaveBeenCalledWith('appVersion', version);
-            expect(fakeFormData.append).toHaveBeenCalledWith('crashType', type);
+            expect(fakeFormData.append).toHaveBeenCalledWith('crashType', type.name);
+            expect(fakeFormData.append).toHaveBeenCalledWith('crashTypeId', `${type.id}`);
             expect(fakeFormData.append).toHaveBeenCalledWith('s3key', url);
             expect(fakeFormData.append).toHaveBeenCalledWith('md5', md5);
             expect(bugsplatApiClient.fetch).toHaveBeenCalledWith(

--- a/src/post/crash-post-client.ts
+++ b/src/post/crash-post-client.ts
@@ -83,7 +83,8 @@ export class CrashPostClient {
         formData.append('database', database);
         formData.append('appName', application);
         formData.append('appVersion', version);
-        formData.append('crashType', crashType);
+        formData.append('crashType', crashType.name);
+        formData.append('crashTypeId', `${crashType.id}`);
         formData.append('s3key', s3Key);
         formData.append('md5', md5);
 

--- a/src/post/crash-type.ts
+++ b/src/post/crash-type.ts
@@ -1,4 +1,7 @@
-export enum CrashType {
-    native = 'Windows.Native',
-    dotnet = 'Windows.NET'
+export class CrashType {
+    static readonly crashpad = new CrashType('Crashpad', 5);
+    static readonly dotnet = new CrashType('Windows.NET', 8);
+    static readonly electron = new CrashType('Electron', 22);
+    static readonly native = new CrashType('Windows.Native', 1);
+    private constructor(public readonly name: string, public readonly id: number) { }
 }


### PR DESCRIPTION
Allows us to post other crash types with Pulse such as Crashpad, Electron, and macOS.