### PR TITLE
fix: safe cancel upload stream

### DIFF
--- a/src/common/cancel.ts
+++ b/src/common/cancel.ts
@@ -1,0 +1,16 @@
+import type { ReadableStream } from 'node:stream/web';
+
+// A stream cannot be closed if there's an active reader.
+// Try and cancel the stream, and ignore the error that's thrown if it's locked.
+// This is exactly what the official node.js fetch implementation does.
+// https://github.com/nodejs/node/issues/42411#issuecomment-1073284684
+// https://github.com/nodejs/node/blob/15b39026197437493af224f0fe69aa878ec1abd3/deps/undici/src/lib/web/fetch/index.js#L331-L336
+export async function safeCancel(stream: ReadableStream): Promise<void> {
+    return stream.cancel().catch((err) => {
+        if (err.code === 'ERR_INVALID_STATE') {
+            // Node bug?
+            return;
+        }
+        throw err;
+    });
+}

--- a/src/symbols/symbols-api-client/symbols-api-client.spec.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.spec.ts
@@ -141,9 +141,9 @@ function createFakeStream(value: any, done: boolean, releaseLock?: jasmine.Spy) 
         getReader: () => ({
             read: () => Promise.resolve({ value, done }),
             releaseLock: releaseLock ?? jasmine.createSpy('releaseLock'),
-            cancel: jasmine.createSpy('reader-cancel')
+            cancel: jasmine.createSpy('reader-cancel').and.resolveTo()
         }),
-        cancel: jasmine.createSpy('stream-cancel')
+        cancel: jasmine.createSpy('stream-cancel').and.resolveTo()
     };
 }
 

--- a/src/symbols/symbols-api-client/symbols-api-client.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.ts
@@ -1,5 +1,6 @@
 import { ApiClient, BugSplatResponse, GZippedSymbolFile, S3ApiClient } from '@common';
 import { delay } from '../../common/delay';
+import { safeCancel } from 'src/common/cancel';
 
 export class SymbolsApiClient {
     private readonly uploadUrl = '/symsrv/uploadUrl';
@@ -38,7 +39,7 @@ export class SymbolsApiClient {
                     // Release the lock, so we can cancel the stream.
                     // See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/tee and https://github.com/whatwg/streams/issues/1033#issuecomment-601471668
                     reader.releaseLock();
-                    checkStream.cancel();
+                    safeCancel(checkStream);
                 }
 
                 let uploadResponse: globalThis.Response;
@@ -67,7 +68,7 @@ export class SymbolsApiClient {
                     // Unfortunately, the original stream gets locked when we tee it, so we can't cancel it directly.
                     // When both teed streams are cancelled, the original stream _should_ also be cancelled.
                     // There's not a lot of documentation on this, so we might be mistaken.
-                    uploadStream.cancel();
+                    safeCancel(uploadStream);
                 }
 
                 await this._timer(1000);


### PR DESCRIPTION
### Description

A stream cannot be closed if there's an active reader. Try and cancel the stream, and ignore the error that's thrown if it's locked. This is exactly what the official node.js fetch implementation does.

Relevant resources:

* https://github.com/nodejs/node/issues/42411#issuecomment-1073284684
* https://github.com/nodejs/node/blob/15b39026197437493af224f0fe69aa878ec1abd3/deps/undici/src/lib/web/fetch/index.js#L331-L336


### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
