### PR TITLE
fix: deprecate old api/crash/data endpoint

### DIFF
--- a/spec/config.ts
+++ b/spec/config.ts
@@ -32,6 +32,13 @@ if (!clientSecret) {
     throw new Error('Please set BUGSPLAT_CLIENT_SECRET env variable');
 }
 
+if (host.includes('octomore')) {
+    // This allows us to use self-signed certificates, or out-of-date certs in our tests.
+    // Without this, Node fetch rejects the requests to octomore.bugsplat.com when we map
+    // it to a local IP address using /etc/hosts.
+    process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0';
+}
+
 export const config = {
     host,
     email,

--- a/src/common/client/bugsplat-api-client/bugsplat-api-client.spec.ts
+++ b/src/common/client/bugsplat-api-client/bugsplat-api-client.spec.ts
@@ -31,7 +31,7 @@ describe('BugSplatApiClient', () => {
     });
 
     describe('fetch', () => {
-        const route = '/api/crash/data';
+        const route = '/api/crash/details';
         let body;
         let headers;
         let init;

--- a/src/crash/crash-api-client/crash-api-client.spec.ts
+++ b/src/crash/crash-api-client/crash-api-client.spec.ts
@@ -106,7 +106,7 @@ describe('CrashApiClient', () => {
         });
 
         it('should call fetch with correct route', () => {
-            expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith('/api/crash/details/reprocess', jasmine.anything());
+            expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith('/api/crash/reprocess', jasmine.anything());
         });
 
         it('should call form data append with processor if provided', async () => {

--- a/src/crash/crash-api-client/crash-api-client.spec.ts
+++ b/src/crash/crash-api-client/crash-api-client.spec.ts
@@ -30,7 +30,7 @@ describe('CrashApiClient', () => {
         });
 
         it('should call fetch with correct route', () => {
-            expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith('/api/crash/data', jasmine.anything());
+            expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith('/api/crash/details', jasmine.anything());
         });
 
         it('should call fetch with formData containing database and id', () => {
@@ -106,7 +106,7 @@ describe('CrashApiClient', () => {
         });
 
         it('should call fetch with correct route', () => {
-            expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith('/api/crash/reprocess', jasmine.anything());
+            expect(fakeBugSplatApiClient.fetch).toHaveBeenCalledWith('/api/crash/details/reprocess', jasmine.anything());
         });
 
         it('should call form data append with processor if provided', async () => {

--- a/src/crash/crash-api-client/crash-api-client.ts
+++ b/src/crash/crash-api-client/crash-api-client.ts
@@ -26,7 +26,7 @@ export class CrashApiClient {
             duplex: 'half'
         } as RequestInit;
 
-        const response = await this._client.fetch<GetCrashByIdResponse>('/api/crash/data', init);
+        const response = await this._client.fetch<GetCrashByIdResponse>('/api/crash/details', init);
         const json = await response.json();
 
         if (response.status !== 200) {
@@ -66,7 +66,7 @@ export class CrashApiClient {
             duplex: 'half'
         } as RequestInit;
 
-        const response = await this._client.fetch<ReprocessCrashResponse>('/api/crash/reprocess', init);
+        const response = await this._client.fetch<ReprocessCrashResponse>('/api/crash/details/reprocess', init);
         const json = await response.json();
 
         if (response.status !== 202) {

--- a/src/crash/crash-api-client/crash-api-client.ts
+++ b/src/crash/crash-api-client/crash-api-client.ts
@@ -66,7 +66,7 @@ export class CrashApiClient {
             duplex: 'half'
         } as RequestInit;
 
-        const response = await this._client.fetch<ReprocessCrashResponse>('/api/crash/details/reprocess', init);
+        const response = await this._client.fetch<ReprocessCrashResponse>('/api/crash/reprocess', init);
         const json = await response.json();
 
         if (response.status !== 202) {

--- a/src/crash/crash-details/crash-details.ts
+++ b/src/crash/crash-details/crash-details.ts
@@ -26,7 +26,6 @@ export enum DefectTrackerType {
 export interface CrashDetails {
   processed: ProcessingStatus;
 
-  additionalFiles: Array<string>;
   appKey: string;
   appName: string;
   appVersion: string;
@@ -91,7 +90,6 @@ export function createCrashDetails(options: CrashDetailsRawResponse): CrashDetai
   const user = defaultToEmptyString(options.user, 'options.user');
 
   ac.assertType(options.thread, ThreadCollection, 'options.thread');
-  ac.assertType(options.additionalFiles, Array, 'options.additionalFiles');
   ac.assertType(options.events, Array, 'options.events');
 
   const events = createEvents(options.events as EventResponseObject[]);


### PR DESCRIPTION
### Description

Endpoint no longer returns attachments. Consumers will need to download the dumpfile zip and traverse it themselves.

BREAKING CHANGE: new api/crash does not return addtionalFiles

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
