### PR TITLE
fix: allow numbers as query filter values

### DIFF
--- a/src/common/data/search/filter/query-filter.ts
+++ b/src/common/data/search/filter/query-filter.ts
@@ -2,7 +2,7 @@ import { QueryFilterCondition } from '../filter-condition/filter-condition';
 
 export class QueryFilter {
   constructor(
-    public readonly filterValue: string,
+    public readonly filterValue: string | number,
     public readonly filterCondition: QueryFilterCondition,
     public readonly filterDataField: string
   ) {

--- a/src/common/data/table-data/table-data-form-data-builder/table-data-form-data-builder.ts
+++ b/src/common/data/table-data/table-data-form-data-builder/table-data-form-data-builder.ts
@@ -34,7 +34,7 @@ export class TableDataFormDataBuilder {
             this._formParts[`filteroperator${filtersCount}`] = firstFilter ? group.groupOperator?.value : group.filterOperator?.value;
             this._formParts[`filterdatafield${filtersCount}`] = filter.filterDataField;
             this._formParts[`filtercondition${filtersCount}`] = filter.filterCondition;
-            this._formParts[`filtervalue${filtersCount}`] = filter.filterValue;
+            this._formParts[`filtervalue${filtersCount}`] = filter.filterValue.toString();
             this._formParts[`filtergroupclose${filtersCount}`] = lastFilter ? '1' : '0';
             filtersCount++;
           });


### PR DESCRIPTION
### Description

Allow number values when creating query filters.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
