### PR TITLE
feat: add dumpfileSize to crash API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9010,7 +9010,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
       "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/spec/fakes/crash/crash-api-response.ts
+++ b/spec/fakes/crash/crash-api-response.ts
@@ -16,6 +16,7 @@ export const createFakeCrashApiResponse = () => ({
     defectUrl: 'http://newayz.net',
     description: 'haa!',
     dumpfile: '💩',
+    dumpfileSize: 42,
     email: 'bobby@newayz.net',
     events: createFakeEvents([EventType.Comment]),
     exceptionCode: '0010',

--- a/src/crash/crash-details/crash-details.spec.ts
+++ b/src/crash/crash-details/crash-details.spec.ts
@@ -29,6 +29,7 @@ describe('createCrashDetails', () => {
       stackId: 11372,
       stackKeyId: 1364,
       dumpfile: '/fred/myconsolecrasher-2019.2.3.0/2019/02/03/myconsolecrasher_2019.2.3.0_orgjilct-1706618358.zip',
+      dumpfileSize: 42,
       appName: 'myConsoleCrasher',
       appVersion: '2019.2.3.0',
       appKey: '',

--- a/src/crash/crash-details/crash-details.ts
+++ b/src/crash/crash-details/crash-details.ts
@@ -75,6 +75,7 @@ export function createCrashDetails(options: CrashDetailsRawResponse): CrashDetai
   ac.assertNumber(<number>options.id, 'options.id');
   ac.assertNumber(<number>options.stackKeyId, 'options.stackKeyId');
   ac.assertBoolean(<boolean>options.missingSymbols, 'options.missingSymbols');
+  ac.assertNumber(<number>options.dumpfileSize, 'options.dumpfileSize');
 
   const appName = defaultToEmptyString(options.appName, 'options.appName');
   const appVersion = defaultToEmptyString(options.appVersion, 'options.appVersion');

--- a/src/crash/crash-details/crash-details.ts
+++ b/src/crash/crash-details/crash-details.ts
@@ -45,6 +45,7 @@ export interface CrashDetails {
   defectUrl: string;
   description: string;
   dumpfile: string;
+  dumpfileSize: number;
   email: string;
   events: Array<Event>;
   exceptionCode: string;


### PR DESCRIPTION
### Description

Adds dumpfileSize to Crash API

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
