### PR TITLE
fix!: retire usage of uid in users endpoint

### DIFF
--- a/src/users/users-api-client/users-api-client.e2e.ts
+++ b/src/users/users-api-client/users-api-client.e2e.ts
@@ -53,8 +53,8 @@ describe('UsersApiClient', () => {
 
     describe('removeUserFromDatabase', () => {
         it('should return 200 and message', async () => {
-            const { uId } = await await usersClient.addUserToDatabase(config.database, testEmail).then(response => response.json());
-            const response = await usersClient.removeUserFromDatabase(config.database, uId);
+            await usersClient.addUserToDatabase(config.database, testEmail);
+            const response = await usersClient.removeUserFromDatabase(config.database, testEmail);
             const body = await response.json();
             expect(response.status).toEqual(200);
             expect(body.status).toEqual(UserApiResponseStatus.success);

--- a/src/users/users-api-client/users-api-client.spec.ts
+++ b/src/users/users-api-client/users-api-client.spec.ts
@@ -5,178 +5,208 @@ import { UsersApiClient } from './users-api-client';
 import { UsersApiRow } from './users-api-row';
 
 describe('UsersApiClient', () => {
-    let sut: UsersApiClient;
+  let sut: UsersApiClient;
 
-    let apiClient;
-    let apiClientResponse;
-    let companyId;
-    let database;
-    let fakeFormData;
-    let rows;
+  let apiClient;
+  let apiClientResponse;
+  let companyId;
+  let database;
+  let fakeFormData;
+  let rows;
 
-    beforeEach(() => {
-        companyId = 123;
-        database = 'zzz';
-        rows = [new UsersApiRow(1, 'x', 1, 'y', 'z', 1, 1, 'a', 'b')];
-        fakeFormData = createFakeFormData();
-        apiClientResponse = createFakeResponseBody(200, rows);
-        apiClient = createFakeBugSplatApiClient(fakeFormData, apiClientResponse);
+  beforeEach(() => {
+    companyId = 123;
+    database = 'zzz';
+    rows = [new UsersApiRow(1, 'x', 1, 'y', 'z', 1, 1, 'a', 'b')];
+    fakeFormData = createFakeFormData();
+    apiClientResponse = createFakeResponseBody(200, rows);
+    apiClient = createFakeBugSplatApiClient(fakeFormData, apiClientResponse);
 
-        sut = new UsersApiClient(apiClient);
+    sut = new UsersApiClient(apiClient);
+  });
+
+  describe('getUsers', () => {
+    let result;
+    let request;
+
+    beforeEach(async () => {
+      request = { database };
+      result = await sut.getUsers(request);
     });
 
-    describe('getUsers', () => {
-        let result;
-        let request;
-
-        beforeEach(async () => {
-            request = { database };
-            result = await sut.getUsers(request);
-        });
-
-        it('should throw if both database and companyId are specified', async () => {
-            request = { database, companyId: 1 };
-            await expectAsync(sut.getUsers(request)).toBeRejectedWithError('Cannot specify both database and companyId');
-        });
-
-        it('should throw if neither database nor companyId are specified', async () => {
-            request = {};
-            await expectAsync(sut.getUsers(request)).toBeRejectedWithError('Must specify either database or companyId');
-        });
-
-        it('should call fetch with url containing database param', () => {
-            expect(apiClient.fetch).toHaveBeenCalledWith(`/api/user/users.php?database=${database}`);
-        });
-
-        it('should call fetch with url containing companyId param', async () => {
-            request = { companyId: 1 };
-            await sut.getUsers(request);
-            expect(apiClient.fetch).toHaveBeenCalledWith(`/api/user/users.php?companyId=${request.companyId}`);
-        });
-
-        it('should return rows from response', () => {
-            expect(result.rows).toEqual(rows);
-        });
+    it('should throw if both database and companyId are specified', async () => {
+      request = { database, companyId: 1 };
+      await expectAsync(sut.getUsers(request)).toBeRejectedWithError(
+        'Cannot specify both database and companyId'
+      );
     });
 
-    describe('addUserToDatabase', () => {
-        let result;
-        let email;
-
-        beforeEach(async () => {
-            email = '☕️';
-            result = await sut.addUserToDatabase(database, email);
-        });
-
-        it('should call createFormData', () => {
-            expect(apiClient.createFormData).toHaveBeenCalled();
-        });
-
-        it('should call append with database and email', () => {
-            expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
-            expect(fakeFormData.append).toHaveBeenCalledWith('username', email);
-        });
-
-        it('should call fetch with url and request containing formData', () => {
-            expect(apiClient.fetch).toHaveBeenCalledWith('/api/user/users.php', jasmine.objectContaining({ method: 'POST', body: fakeFormData }));
-        });
-
-        it('should return response', () => {
-            expect(result).toEqual(apiClientResponse);
-        });
+    it('should throw if neither database nor companyId are specified', async () => {
+      request = {};
+      await expectAsync(sut.getUsers(request)).toBeRejectedWithError(
+        'Must specify either database or companyId'
+      );
     });
 
-    describe('removeUserFromDatabase', () => {
-        let result;
-        let uId;
-
-        beforeEach(async () => {
-            uId = 1;
-            result = await sut.removeUserFromDatabase(database, uId);
-        });
-
-        it('should call fetch with url', () => {
-            expect(apiClient.fetch).toHaveBeenCalledWith(`/api/user/users.php?database=${database}&uId=${uId}`, jasmine.objectContaining({ method: 'DELETE' }));
-        });
-
-        it('should return response', () => {
-            expect(result).toEqual(apiClientResponse);
-        });
+    it('should call fetch with url containing database param', () => {
+      expect(apiClient.fetch).toHaveBeenCalledWith(
+        `/api/user/users.php?database=${database}`
+      );
     });
 
-    describe('updateUserForDatabase', () => {
-        let result;
-        let email;
-        let isRestricted;
-
-        beforeEach(async () => {
-            email = 'fred@bugsplat.com';
-            isRestricted = true;
-            result = await sut.updateUserForDatabase(database, email, isRestricted);
-        });
-
-        it('should call createFormData', () => {
-            expect(apiClient.createFormData).toHaveBeenCalled();
-        });
-
-        it('should call append with database and email', () => {
-            expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
-            expect(fakeFormData.append).toHaveBeenCalledWith('username', email);
-            expect(fakeFormData.append).toHaveBeenCalledWith('rights', isRestricted ? '0' : '1');
-        });
-
-        it('should call fetch with url and request containing formData', () => {
-            expect(apiClient.fetch).toHaveBeenCalledWith('/api/user/users.php', jasmine.objectContaining({ method: 'POST', body: fakeFormData }));
-        });
-
-        it('should return response', () => {
-            expect(result).toEqual(apiClientResponse);
-        });
+    it('should call fetch with url containing companyId param', async () => {
+      request = { companyId: 1 };
+      await sut.getUsers(request);
+      expect(apiClient.fetch).toHaveBeenCalledWith(
+        `/api/user/users.php?companyId=${request.companyId}`
+      );
     });
 
-    describe('addUserToCompany', () => {
-        let result;
-        let email;
+    it('should return rows from response', () => {
+      expect(result.rows).toEqual(rows);
+    });
+  });
 
-        beforeEach(async () => {
-            email = '☕️';
-            result = await sut.addUserToCompany(companyId, email);
-        });
+  describe('addUserToDatabase', () => {
+    let result;
+    let email;
 
-
-        it('should call createFormData', () => {
-            expect(apiClient.createFormData).toHaveBeenCalled();
-        });
-
-        it('should call append with companyId and email', () => {
-            expect(fakeFormData.append).toHaveBeenCalledWith('companyId', `${companyId}`);
-            expect(fakeFormData.append).toHaveBeenCalledWith('username', email);
-        });
-
-        it('should call fetch with url and request containing formData', () => {
-            expect(apiClient.fetch).toHaveBeenCalledWith('/api/user/users.php', jasmine.objectContaining({ method: 'POST', body: fakeFormData }));
-        });
-
-        it('should return response', () => {
-            expect(result).toEqual(apiClientResponse);
-        });
+    beforeEach(async () => {
+      email = '☕️';
+      result = await sut.addUserToDatabase(database, email);
     });
 
-    describe('removeUserFromCompany', () => {
-        let result;
-        let uId;
-
-        beforeEach(async () => {
-            uId = 1;
-            result = await sut.removeUserFromCompany(companyId, uId);
-        });
-
-        it('should call fetch with url', () => {
-            expect(apiClient.fetch).toHaveBeenCalledWith(`/api/user/users.php?companyId=${companyId}&uId=${uId}`, jasmine.objectContaining({ method: 'DELETE' }));
-        });
-
-        it('should return response', () => {
-            expect(result).toEqual(apiClientResponse);
-        });
+    it('should call createFormData', () => {
+      expect(apiClient.createFormData).toHaveBeenCalled();
     });
+
+    it('should call append with database and email', () => {
+      expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
+      expect(fakeFormData.append).toHaveBeenCalledWith('username', email);
+    });
+
+    it('should call fetch with url and request containing formData', () => {
+      expect(apiClient.fetch).toHaveBeenCalledWith(
+        '/api/user/users.php',
+        jasmine.objectContaining({ method: 'POST', body: fakeFormData })
+      );
+    });
+
+    it('should return response', () => {
+      expect(result).toEqual(apiClientResponse);
+    });
+  });
+
+  describe('removeUserFromDatabase', () => {
+    let result;
+    let email;
+
+    beforeEach(async () => {
+      email = 'test@bugsplat.com';
+      result = await sut.removeUserFromDatabase(database, email);
+    });
+
+    it('should call fetch with url', () => {
+      expect(apiClient.fetch).toHaveBeenCalledWith(
+        `/api/user/users.php?database=${database}&username=${encodeURIComponent(
+          email
+        )}`,
+        jasmine.objectContaining({ method: 'DELETE' })
+      );
+    });
+
+    it('should return response', () => {
+      expect(result).toEqual(apiClientResponse);
+    });
+  });
+
+  describe('updateUserForDatabase', () => {
+    let result;
+    let email;
+    let isRestricted;
+
+    beforeEach(async () => {
+      email = 'fred@bugsplat.com';
+      isRestricted = true;
+      result = await sut.updateUserForDatabase(database, email, isRestricted);
+    });
+
+    it('should call createFormData', () => {
+      expect(apiClient.createFormData).toHaveBeenCalled();
+    });
+
+    it('should call append with database and email', () => {
+      expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
+      expect(fakeFormData.append).toHaveBeenCalledWith('username', email);
+      expect(fakeFormData.append).toHaveBeenCalledWith(
+        'rights',
+        isRestricted ? '0' : '1'
+      );
+    });
+
+    it('should call fetch with url and request containing formData', () => {
+      expect(apiClient.fetch).toHaveBeenCalledWith(
+        '/api/user/users.php',
+        jasmine.objectContaining({ method: 'POST', body: fakeFormData })
+      );
+    });
+
+    it('should return response', () => {
+      expect(result).toEqual(apiClientResponse);
+    });
+  });
+
+  describe('addUserToCompany', () => {
+    let result;
+    let email;
+
+    beforeEach(async () => {
+      email = '☕️';
+      result = await sut.addUserToCompany(companyId, email);
+    });
+
+    it('should call createFormData', () => {
+      expect(apiClient.createFormData).toHaveBeenCalled();
+    });
+
+    it('should call append with companyId and email', () => {
+      expect(fakeFormData.append).toHaveBeenCalledWith(
+        'companyId',
+        `${companyId}`
+      );
+      expect(fakeFormData.append).toHaveBeenCalledWith('username', email);
+    });
+
+    it('should call fetch with url and request containing formData', () => {
+      expect(apiClient.fetch).toHaveBeenCalledWith(
+        '/api/user/users.php',
+        jasmine.objectContaining({ method: 'POST', body: fakeFormData })
+      );
+    });
+
+    it('should return response', () => {
+      expect(result).toEqual(apiClientResponse);
+    });
+  });
+
+  describe('removeUserFromCompany', () => {
+    let result;
+    let uId;
+
+    beforeEach(async () => {
+      uId = 1;
+      result = await sut.removeUserFromCompany(companyId, uId);
+    });
+
+    it('should call fetch with url', () => {
+      expect(apiClient.fetch).toHaveBeenCalledWith(
+        `/api/user/users.php?companyId=${companyId}&uId=${uId}`,
+        jasmine.objectContaining({ method: 'DELETE' })
+      );
+    });
+
+    it('should return response', () => {
+      expect(result).toEqual(apiClientResponse);
+    });
+  });
 });

--- a/src/users/users-api-client/users-api-client.ts
+++ b/src/users/users-api-client/users-api-client.ts
@@ -4,148 +4,185 @@ import { UsersApiRow } from './users-api-row';
 
 const USERS_BASE_URL = '/api/user/users.php';
 export class UsersApiClient {
+  constructor(private _client: ApiClient) {}
 
-    constructor(private _client: ApiClient) { }
+  async getUsers(
+    request: UsersTableDataRequest
+  ): Promise<TableDataResponse<UsersApiRow>> {
+    const { database, companyId, email } = request;
+    if (database && companyId) {
+      throw new Error('Cannot specify both database and companyId');
+    }
+    if (!database && !companyId) {
+      throw new Error('Must specify either database or companyId');
+    }
+    const params = new URLSearchParams();
+    if (database) {
+      params.append('database', database);
+    }
+    if (companyId) {
+      params.append('companyId', companyId.toString());
+    }
+    if (email) {
+      params.append('username', email);
+    }
+    const url = `${USERS_BASE_URL}?${params.toString()}`;
+    const response = await this._client.fetch<Array<UsersApiRow>>(url);
+    const rows = await response.json();
 
-    async getUsers(request: UsersTableDataRequest): Promise<TableDataResponse<UsersApiRow>> {
-        const { database, companyId, email } = request;
-        if (database && companyId) {
-            throw new Error('Cannot specify both database and companyId');
-        }
-        if (!database && !companyId) {
-            throw new Error('Must specify either database or companyId');
-        }
-        const params = new URLSearchParams();
-        if (database) {
-            params.append('database', database);
-        }
-        if (companyId) {
-            params.append('companyId', companyId.toString());
-        }
-        if (email) {
-            params.append('username', email);
-        }
-        const url = `${USERS_BASE_URL}?${params.toString()}`;
-        const response = await this._client.fetch<Array<UsersApiRow>>(url);
-        const rows = await response.json();
+    return {
+      rows,
+    };
+  }
 
-        return {
-            rows
-        };
+  async addUserToDatabase(
+    database: string,
+    email: string
+  ): Promise<BugSplatResponse<AddUserResponse>> {
+    const formData = this._client.createFormData();
+    formData.append('database', database);
+    formData.append('username', email);
+    const request = {
+      method: 'POST',
+      cache: 'no-cache',
+      credentials: 'include',
+      redirect: 'follow',
+      body: formData,
+    } as RequestInit;
+
+    const response = await this._client.fetch<AddUserResponse>(
+      USERS_BASE_URL,
+      request
+    );
+    if (response.status !== 200) {
+      throw new Error(
+        `Error adding user ${email} to database ${database} status ${response.status}`
+      );
     }
 
-    async addUserToDatabase(database: string, email: string): Promise<BugSplatResponse<AddUserResponse>> {
-        const formData = this._client.createFormData();
-        formData.append('database', database);
-        formData.append('username', email);
-        const request = {
-            method: 'POST',
-            cache: 'no-cache',
-            credentials: 'include',
-            redirect: 'follow',
-            body: formData
-        } as RequestInit;
+    return response;
+  }
 
-        const response = await this._client.fetch<AddUserResponse>(USERS_BASE_URL, request);
-        if (response.status !== 200) {
-            throw new Error(`Error adding user ${email} to database ${database} status ${response.status}`);
-        }
+  async removeUserFromDatabase(
+    database: string,
+    email: string
+  ): Promise<BugSplatResponse<UsersApiResponse>> {
+    const url = `${USERS_BASE_URL}?database=${database}&username=${encodeURIComponent(
+      email
+    )}`;
+    const request = {
+      method: 'DELETE',
+      cache: 'no-cache',
+      credentials: 'include',
+      redirect: 'follow',
+    } as RequestInit;
 
-        return response;
+    const response = await this._client.fetch<UsersApiResponse>(url, request);
+    if (response.status !== 200) {
+      throw new Error(
+        `Error remove user ${email} for ${database} status ${response.status}`
+      );
     }
 
-    async removeUserFromDatabase(database: string, uId: number): Promise<BugSplatResponse<UsersApiResponse>> {
-        const url = `${USERS_BASE_URL}?database=${database}&uId=${uId}`;
-        const request = {
-            method: 'DELETE',
-            cache: 'no-cache',
-            credentials: 'include',
-            redirect: 'follow'
-        } as RequestInit;
+    return response;
+  }
 
-        const response = await this._client.fetch<UsersApiResponse>(url, request);
-        if (response.status !== 200) {
-            throw new Error(`Error remove user ${uId} for ${database} status ${response.status}`);
-        }
+  async updateUserForDatabase(
+    database: string,
+    email: string,
+    isRestricted: boolean
+  ): Promise<BugSplatResponse<AddUserResponse>> {
+    const rights = isRestricted ? '0' : '1';
+    const formData = this._client.createFormData();
+    formData.append('database', database);
+    formData.append('username', email);
+    formData.append('rights', rights);
 
-        return response;
+    const request = {
+      method: 'POST',
+      cache: 'no-cache',
+      credentials: 'include',
+      redirect: 'follow',
+      body: formData,
+    } as RequestInit;
+
+    const response = await this._client.fetch<AddUserResponse>(
+      USERS_BASE_URL,
+      request
+    );
+    if (response.status !== 200) {
+      throw new Error(
+        `Error updating user ${email} in database ${database} status ${response.status}`
+      );
     }
 
-    async updateUserForDatabase(database: string, email: string, isRestricted: boolean): Promise<BugSplatResponse<AddUserResponse>> {
-        const rights = isRestricted ? '0' : '1';
-        const formData = this._client.createFormData();
-        formData.append('database', database);
-        formData.append('username', email);
-        formData.append('rights', rights);
+    return response;
+  }
 
-        const request = {
-            method: 'POST',
-            cache: 'no-cache',
-            credentials: 'include',
-            redirect: 'follow',
-            body: formData
-        } as RequestInit;
+  async addUserToCompany(
+    companyId: number,
+    email: string
+  ): Promise<BugSplatResponse<AddUserResponse>> {
+    const formData = this._client.createFormData();
+    formData.append('companyId', companyId.toString());
+    formData.append('username', email);
+    const request = {
+      method: 'POST',
+      cache: 'no-cache',
+      credentials: 'include',
+      redirect: 'follow',
+      body: formData,
+    } as RequestInit;
 
-        const response = await this._client.fetch<AddUserResponse>(USERS_BASE_URL, request);
-        if (response.status !== 200) {
-            throw new Error(`Error updating user ${email} in database ${database} status ${response.status}`);
-        }
-
-        return response;
+    const response = await this._client.fetch<AddUserResponse>(
+      USERS_BASE_URL,
+      request
+    );
+    if (response.status !== 200) {
+      throw new Error(
+        `Error adding user ${email} to company ${companyId} status ${response.status}`
+      );
     }
 
-    async addUserToCompany(companyId: number, email: string): Promise<BugSplatResponse<AddUserResponse>> {
-        const formData = this._client.createFormData();
-        formData.append('companyId', companyId.toString());
-        formData.append('username', email);
-        const request = {
-            method: 'POST',
-            cache: 'no-cache',
-            credentials: 'include',
-            redirect: 'follow',
-            body: formData
-        } as RequestInit;
+    return response;
+  }
 
-        const response = await this._client.fetch<AddUserResponse>(USERS_BASE_URL, request);
-        if (response.status !== 200) {
-            throw new Error(`Error adding user ${email} to company ${companyId} status ${response.status}`);
-        }
+  async removeUserFromCompany(
+    companyId: number,
+    uId: number
+  ): Promise<BugSplatResponse<UsersApiResponse>> {
+    const url = `${USERS_BASE_URL}?companyId=${companyId}&uId=${uId}`;
+    const request = {
+      method: 'DELETE',
+      cache: 'no-cache',
+      credentials: 'include',
+      redirect: 'follow',
+    } as RequestInit;
 
-        return response;
+    const response = await this._client.fetch<UsersApiResponse>(url, request);
+    if (response.status !== 200) {
+      throw new Error(
+        `Error removing user ${uId} for company ${companyId} status ${response.status}`
+      );
     }
 
-    async removeUserFromCompany(companyId: number, uId: number): Promise<BugSplatResponse<UsersApiResponse>> {
-        const url = `${USERS_BASE_URL}?companyId=${companyId}&uId=${uId}`;
-        const request = {
-            method: 'DELETE',
-            cache: 'no-cache',
-            credentials: 'include',
-            redirect: 'follow'
-        } as RequestInit;
-
-        const response = await this._client.fetch<UsersApiResponse>(url, request);
-        if (response.status !== 200) {
-            throw new Error(`Error removing user ${uId} for company ${companyId} status ${response.status}`);
-        }
-
-        return response;
-    }
+    return response;
+  }
 }
 
-
 export enum UserApiResponseStatus {
-    success = 'success',
-    warning = 'warning',
-    fail = 'fail',
+  success = 'success',
+  warning = 'warning',
+  fail = 'fail',
 }
 
 export interface UsersApiResponse {
-    status: UserApiResponseStatus;
-    message?: string;
+  status: UserApiResponseStatus;
+  message?: string;
 }
 
 export interface AddUserResponse extends UsersApiResponse {
-    database?: string;
-    companyId?: number;
-    uId: number;
+  database?: string;
+  companyId?: number;
+  uId: number;
 }


### PR DESCRIPTION
### Description

Cleanup from a few months ago.

BREAKING CHANGE: users are removed by email instead of uid

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
