### PR TITLE
feat!: crash attributes

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,10 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "bracketSpacing": true,
+  "trailingComma": "es5",
+  "printWidth": 100,
+  "tabWidth": 2,
+  "useTabs": false,
+  "endOfLine": "lf"
+} 

--- a/spec/files/native/post-native-crash.ts
+++ b/spec/files/native/post-native-crash.ts
@@ -34,13 +34,12 @@ export async function postNativeCrash(
 ): Promise<PostCrashResponse> {
     const crashFile = await createUploadableFile('./spec/files/native/myConsoleCrasher.zip');
     const crashPostClient = new CrashPostClient(database);
-    await delay(2000); // Prevent rate-limiting
+    await delay(1000); // Prevent rate-limiting
     const postCrashResult = await crashPostClient.postCrash(
         application,
         version,
         CrashType.native,
         crashFile,
-        'ebe24c1cd1a0912904658fa4fad2b539'
     );
     return postCrashResult.json();
 }

--- a/src/post/crash-post-client.e2e.ts
+++ b/src/post/crash-post-client.e2e.ts
@@ -1,6 +1,7 @@
 import { CrashPostClient, CrashType } from '@post';
 import { createUploadableFile } from '@spec/files/create-bugsplat-file';
 import { delay } from '../common/delay';
+import { config } from '@spec/config';
 
 describe('CrashPostClient', () => {
   beforeEach(async () => delay(1000)); // Prevent rate-limiting
@@ -10,7 +11,7 @@ describe('CrashPostClient', () => {
       const application = 'myConsoleCrasher';
       const version = `${Math.random() * 1000000}`;
       const crashFile = await createUploadableFile('spec/files/native/myConsoleCrasher.zip');
-      const crashPostClient = new CrashPostClient('octomore');
+      const crashPostClient = new CrashPostClient(config.database);
       const attributes = {
         test: 'test',
       };

--- a/src/post/crash-post-client.e2e.ts
+++ b/src/post/crash-post-client.e2e.ts
@@ -4,21 +4,23 @@ import { createUploadableFile } from '@spec/files/create-bugsplat-file';
 import { delay } from '../common/delay';
 
 describe('CrashPostClient', () => {
-    beforeEach(async () => delay(2000));  // Prevent rate-limiting
+    beforeEach(async () => delay(1000));  // Prevent rate-limiting
 
     describe('postCrash', () => {
         it('should post crash to BugSplat and return 200', async () => {
             const application = 'myConsoleCrasher';
             const version = `${Math.random() * 1000000}`;
-            const md5 = 'ebe24c1cd1a0912904658fa4fad2b539';
             const crashFile = await createUploadableFile('spec/files/native/myConsoleCrasher.zip');
             const crashPostClient = new CrashPostClient(config.database);
+            const attributes = {
+                'test': 'test'
+            };
             const result = await crashPostClient.postCrash(
                 application,
                 version,
                 CrashType.native,
                 crashFile,
-                md5
+                attributes
             );
             const json = await result.json();
 

--- a/src/post/crash-post-client.e2e.ts
+++ b/src/post/crash-post-client.e2e.ts
@@ -1,31 +1,30 @@
 import { CrashPostClient, CrashType } from '@post';
-import { config } from '@spec/config';
 import { createUploadableFile } from '@spec/files/create-bugsplat-file';
 import { delay } from '../common/delay';
 
 describe('CrashPostClient', () => {
-    beforeEach(async () => delay(1000));  // Prevent rate-limiting
+  beforeEach(async () => delay(1000)); // Prevent rate-limiting
 
-    describe('postCrash', () => {
-        it('should post crash to BugSplat and return 200', async () => {
-            const application = 'myConsoleCrasher';
-            const version = `${Math.random() * 1000000}`;
-            const crashFile = await createUploadableFile('spec/files/native/myConsoleCrasher.zip');
-            const crashPostClient = new CrashPostClient(config.database);
-            const attributes = {
-                'test': 'test'
-            };
-            const result = await crashPostClient.postCrash(
-                application,
-                version,
-                CrashType.native,
-                crashFile,
-                attributes
-            );
-            const json = await result.json();
+  describe('postCrash', () => {
+    it('should post crash to BugSplat and return 200', async () => {
+      const application = 'myConsoleCrasher';
+      const version = `${Math.random() * 1000000}`;
+      const crashFile = await createUploadableFile('spec/files/native/myConsoleCrasher.zip');
+      const crashPostClient = new CrashPostClient('octomore');
+      const attributes = {
+        test: 'test',
+      };
+      const result = await crashPostClient.postCrash(
+        application,
+        version,
+        CrashType.native,
+        crashFile,
+        attributes
+      );
+      const json = await result.json();
 
-            expect(result.status).toEqual(200);
-            expect(json.crashId).toBeGreaterThan(0);
-        });
+      expect(result.status).toEqual(200);
+      expect(json.crashId).toBeGreaterThan(0);
     });
+  });
 });

--- a/src/post/crash-post-client.spec.ts
+++ b/src/post/crash-post-client.spec.ts
@@ -1,4 +1,4 @@
-import { Environment } from '@common';
+import { Environment, UploadableFile } from '@common';
 import { CrashPostClient, CrashType } from '@post';
 import { createFakeBugSplatApiClient } from '@spec/fakes/common/bugsplat-api-client';
 import { createFakeFormData } from '@spec/fakes/common/form-data';
@@ -15,26 +15,29 @@ describe('CrashPostClient', () => {
     let fakeGetUploadUrlResponse;
     let s3ApiClient;
 
-    let application;
-    let database;
-    let file;
-    let ipAddress;
-    let md5;
-    let type;
-    let url;
-    let version;
+    let application: string;
+    let attributes: Record<string, string>;
+    let database: string;
+    let file: UploadableFile;
+    let ipAddress: string;
+    let type: CrashType;
+    let url: string;
+    let version: string;
 
     let result;
 
     beforeEach(() => {
         database = 'pumpkin';
         application = 'spice';
-        file = { name: 'pumpkin-spice-latte-recipe.txt', file: '🎃🌶☕️', size: 100 };
+        attributes = {
+            'test': 'test'
+        };
+        file = { name: 'pumpkin-spice-latte-recipe.txt', file: '🎃🌶☕️' as any, size: 100 };
         ipAddress = '127.0.0.1';
-        md5 = '93aebd31ecc781f6574cc396a1e0c4d2';
         type = CrashType.native;
         url = 'https://cassies.coffee/yum';
         version = 'latte';
+
         fakeFormData = createFakeFormData();
         fakeCommitS3UploadResponse = createFakeResponseBody(200);
         fakeGetUploadUrlResponse = createFakeResponseBody(200, { url });
@@ -59,7 +62,7 @@ describe('CrashPostClient', () => {
                 version,
                 type,
                 file,
-                md5
+                attributes
             );
         });
 
@@ -79,7 +82,7 @@ describe('CrashPostClient', () => {
             expect(fakeFormData.append).toHaveBeenCalledWith('crashType', type.name);
             expect(fakeFormData.append).toHaveBeenCalledWith('crashTypeId', `${type.id}`);
             expect(fakeFormData.append).toHaveBeenCalledWith('s3key', url);
-            expect(fakeFormData.append).toHaveBeenCalledWith('md5', md5);
+            expect(fakeFormData.append).toHaveBeenCalledWith('attributes', JSON.stringify(attributes));
             expect(bugsplatApiClient.fetch).toHaveBeenCalledWith(
                 '/api/commitS3CrashUpload',
                 jasmine.objectContaining({

--- a/src/post/crash-post-client.ts
+++ b/src/post/crash-post-client.ts
@@ -23,7 +23,7 @@ export class CrashPostClient {
         version: string,
         type: CrashType,
         file: UploadableFile,
-        md5 = ''
+        attributes?: Record<string, string>
     ): Promise<BugSplatResponse<PostCrashResponse>> {
         const uploadUrl = await this.getCrashUploadUrl(
             this._database,
@@ -40,7 +40,7 @@ export class CrashPostClient {
             application,
             version,
             type,
-            md5,
+            attributes,
             this._processor
         );
     }
@@ -75,7 +75,7 @@ export class CrashPostClient {
         application: string,
         version: string,
         crashType: CrashType,
-        md5: string,
+        attributes?: Record<string, string>,
         processor?: string,
     ): Promise<BugSplatResponse<PostCrashResponse>> {
         const route = '/api/commitS3CrashUpload';
@@ -86,7 +86,10 @@ export class CrashPostClient {
         formData.append('crashType', crashType.name);
         formData.append('crashTypeId', `${crashType.id}`);
         formData.append('s3key', s3Key);
-        formData.append('md5', md5);
+
+        if (attributes) {
+            formData.append('attributes', JSON.stringify(attributes));
+        }
 
         if (processor) {
             formData.append('processor', processor);

--- a/src/post/crash-type.ts
+++ b/src/post/crash-type.ts
@@ -6,5 +6,6 @@ export class CrashType {
     static readonly mac = new CrashType('macOS', 13);
     static readonly ps4 = new CrashType('PlayStation 4', 28);
     static readonly ps5 = new CrashType('PlayStation 5', 29);
+    static readonly xml = new CrashType('Xml.Report', 21);
     private constructor(public readonly name: string, public readonly id: number) { }
 }


### PR DESCRIPTION
### Description

Adds attributes to Crash uploads.

BREAKING CHANGE: removes md5, no longer used

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
