### PR TITLE
fix: update to new notes API

### DIFF
--- a/src/crashes/crashes-api-client/crashes-api-client.spec.ts
+++ b/src/crashes/crashes-api-client/crashes-api-client.spec.ts
@@ -5,95 +5,95 @@ import { createFakeResponseBody } from '@spec/fakes/common/response';
 import * as TableDataClientModule from '../../common/data/table-data/table-data-client/table-data-client';
 
 describe('CrashesApiClient', () => {
-    let sut: CrashesApiClient;
+  let sut: CrashesApiClient;
 
-    let apiClient;
-    let apiClientResponse;
-    let database;
-    let fakeFormData;
-    let id;
-    let pageData;
-    let rows;
-    let tableDataClient;
-    let tableDataClientResponse;
-    let Comments;
-    let IpAddress;
+  let apiClient;
+  let apiClientResponse;
+  let database;
+  let fakeFormData;
+  let id;
+  let pageData;
+  let rows;
+  let tableDataClient;
+  let tableDataClientResponse;
+  let Comments;
+  let IpAddress;
 
-    beforeEach(() => {
-        fakeFormData = createFakeFormData();
-        apiClientResponse = createFakeResponseBody(200);
-        apiClient = createFakeBugSplatApiClient(fakeFormData, apiClientResponse);
+  beforeEach(() => {
+    fakeFormData = createFakeFormData();
+    apiClientResponse = createFakeResponseBody(200);
+    apiClient = createFakeBugSplatApiClient(fakeFormData, apiClientResponse);
 
-        id = 9001;
-        database = '☕️';
-        Comments = 'it\'s over 9000!';
-        IpAddress = '🏡';
-        pageData = { coffee: 'black rifle' };
-        rows = [{ id, Comments, IpAddress }];
-        tableDataClientResponse = createFakeResponseBody(200, { pageData, rows });
-        tableDataClient = jasmine.createSpyObj('TableDataClient', ['postGetData']);
-        tableDataClient.postGetData.and.resolveTo(tableDataClientResponse);
-        spyOn(TableDataClientModule, 'TableDataClient').and.returnValue(tableDataClient);
+    id = 9001;
+    database = '☕️';
+    Comments = 'it\'s over 9000!';
+    IpAddress = '🏡';
+    pageData = { coffee: 'black rifle' };
+    rows = [{ id, Comments, IpAddress }];
+    tableDataClientResponse = createFakeResponseBody(200, { pageData, rows });
+    tableDataClient = jasmine.createSpyObj('TableDataClient', ['postGetData']);
+    tableDataClient.postGetData.and.resolveTo(tableDataClientResponse);
+    spyOn(TableDataClientModule, 'TableDataClient').and.returnValue(tableDataClient);
 
-        sut = new CrashesApiClient(apiClient);
+    sut = new CrashesApiClient(apiClient);
+  });
+
+  describe('getCrashes', () => {
+    let result;
+    let request;
+
+    beforeEach(async () => {
+      request = { database };
+      result = await sut.getCrashes(request);
     });
 
-    describe('getCrashes', () => {
-        let result;
-        let request;
-
-        beforeEach(async () => {
-            request = { database };
-            result = await sut.getCrashes(request);
-        });
-
-        it('should call postGetData with request', () => {
-            expect(tableDataClient.postGetData).toHaveBeenCalledWith(request);
-        });
-
-        it('should return value with Comments and IpAddress values mapped to lower-case', () => {
-            expect(result.pageData).toEqual(pageData);
-            expect(result.rows[0].id).toEqual(id);
-            expect(result.rows[0].comments).toEqual(Comments);
-            expect(result.rows[0].ipAddress).toEqual(IpAddress);
-        });
+    it('should call postGetData with request', () => {
+      expect(tableDataClient.postGetData).toHaveBeenCalledWith(request);
     });
 
-    describe('postNotes', () => {
-        let result;
-        let notes;
-
-        beforeEach(async () => {
-            notes = 'bulletproof coffee';
-            result = await sut.postNotes(database, id, notes);
-        });
-
-        it('should append, update true, database, id, and Comments to formData', () => {
-            expect(fakeFormData.append).toHaveBeenCalledWith('update', 'true');
-            expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
-            expect(fakeFormData.append).toHaveBeenCalledWith('id', `${id}`);
-            expect(fakeFormData.append).toHaveBeenCalledWith('Comments', notes);
-        });
-
-        it('should call fetch with correct route', () => {
-            expect(apiClient.fetch).toHaveBeenCalledWith('/browse/allcrash.php', jasmine.anything());
-        });
-
-        it('should call fetch with requestInit containing formData', () => {
-            expect(apiClient.fetch).toHaveBeenCalledWith(
-                jasmine.anything(),
-                jasmine.objectContaining({
-                    method: 'POST',
-                    body: fakeFormData,
-                    cache: 'no-cache',
-                    credentials: 'include',
-                    redirect: 'follow'
-                })
-            );
-        });
-
-        it('should return result', () => {
-            expect(result).toEqual(apiClientResponse);
-        });
+    it('should return value with Comments and IpAddress values mapped to lower-case', () => {
+      expect(result.pageData).toEqual(pageData);
+      expect(result.rows[0].id).toEqual(id);
+      expect(result.rows[0].comments).toEqual(Comments);
+      expect(result.rows[0].ipAddress).toEqual(IpAddress);
     });
+  });
+
+  describe('postNotes', () => {
+    let result;
+    let notes;
+
+    beforeEach(async () => {
+      notes = 'bulletproof coffee';
+      result = await sut.postNotes(database, id, notes);
+    });
+
+    it('should append, update true, database, id, and Comments to formData', () => {
+      expect(fakeFormData.append).toHaveBeenCalledWith('update', 'true');
+      expect(fakeFormData.append).toHaveBeenCalledWith('database', database);
+      expect(fakeFormData.append).toHaveBeenCalledWith('id', `${id}`);
+      expect(fakeFormData.append).toHaveBeenCalledWith('notes', notes);
+    });
+
+    it('should call fetch with correct route', () => {
+      expect(apiClient.fetch).toHaveBeenCalledWith('/api/crash/notes.php', jasmine.anything());
+    });
+
+    it('should call fetch with requestInit containing formData', () => {
+      expect(apiClient.fetch).toHaveBeenCalledWith(
+        jasmine.anything(),
+        jasmine.objectContaining({
+          method: 'POST',
+          body: fakeFormData,
+          cache: 'no-cache',
+          credentials: 'include',
+          redirect: 'follow',
+        })
+      );
+    });
+
+    it('should return result', () => {
+      expect(result).toEqual(apiClientResponse);
+    });
+  });
 });

--- a/src/crashes/crashes-api-client/crashes-api-client.ts
+++ b/src/crashes/crashes-api-client/crashes-api-client.ts
@@ -12,16 +12,10 @@ export class CrashesApiClient {
   private _tableDataClient: TableDataClient;
 
   constructor(private _client: ApiClient) {
-    this._tableDataClient = new TableDataClient(
-      this._client,
-      '/api/crashes.php'
-    );
+    this._tableDataClient = new TableDataClient(this._client, '/api/crashes.php');
   }
 
-  async deleteCrashes(
-    database: string,
-    ids: number[]
-  ): Promise<BugSplatResponse> {
+  async deleteCrashes(database: string, ids: number[]): Promise<BugSplatResponse> {
     const urlParams = new URLSearchParams({ database, ids: ids.join(',') });
     const request = {
       method: 'DELETE',
@@ -50,17 +44,12 @@ export class CrashesApiClient {
     };
   }
 
-  // TODO BG we should move this to an api/crash/notes endpoint and reture allcrash
-  postNotes(
-    database: string,
-    id: number,
-    notes: string
-  ): Promise<BugSplatResponse> {
+  postNotes(database: string, id: number, notes: string): Promise<BugSplatResponse> {
     const formData = this._client.createFormData();
     formData.append('update', 'true');
     formData.append('database', database);
     formData.append('id', `${id}`);
-    formData.append('Comments', notes);
+    formData.append('notes', notes);
 
     const request = {
       method: 'POST',
@@ -71,6 +60,6 @@ export class CrashesApiClient {
       duplex: 'half',
     } as RequestInit;
 
-    return this._client.fetch('/browse/allcrash.php', request);
+    return this._client.fetch('/api/crash/notes.php', request);
   }
 }


### PR DESCRIPTION
### Description

Removes last internal usage of legacy `/browse` endpoints.

### Checklist

- [ ] Tested manually
- [ ] Unit tests pass with no errors or warnings
- [ ] Documentation updated (if applicable)
- [ ] Reviewed by at least 1 other contributor
