### PR TITLE
fix!: migrate to summary v2 endpoint

### DIFF
--- a/src/summary/summary-api-client/summary-api-client.ts
+++ b/src/summary/summary-api-client/summary-api-client.ts
@@ -7,7 +7,7 @@ export class SummaryApiClient {
     private _tableDataClient: TableDataClient;
 
     constructor(private _client: ApiClient) {
-        this._tableDataClient = new TableDataClient(this._client, '/summary?data');
+        this._tableDataClient = new TableDataClient(this._client, 'api/v2/summary');
     }
 
     async getSummary(request: SummaryTableDataRequest): Promise<TableDataResponse<SummaryApiRow>> {


### PR DESCRIPTION
### Description

So we can use startDate and endDate to filter the summary page instead of firstReport and lastReport.

Depends on https://github.com/BugSplat-Git/webroot/pull/1461

BREAKING CHANGE: summary is now filtered by startDate and endDate not firstReport and lastReport

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
