### PR TITLE
fix: add ignored status for crash details

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,10 @@ jobs:
         with:
           persist-credentials: false
       
+      # Pin to Node.js 22.12 as 22.18+ breaks tsconfig-paths/register functionality
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.x"
+          node-version: "22.12"
 
       - name: Install
         run: npm install

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
         "typescript": "^5.7.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=18.0.0 <22.13.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -69,7 +69,6 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tsconfig-replace-paths": "^0.0.14",
-    "tsx": "^4.20.4",
     "typescript": "^5.7.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=18.0.0 <22.13.0"
   },
   "scripts": {
     "prepare": "husky install",
@@ -69,6 +69,7 @@
     "ts-node": "^10.9.2",
     "tsconfig-paths": "^4.2.0",
     "tsconfig-replace-paths": "^0.0.14",
+    "tsx": "^4.20.4",
     "typescript": "^5.7.2"
   }
 }

--- a/src/common/client/bugsplat-api-client/bugsplat-api-client.spec.ts
+++ b/src/common/client/bugsplat-api-client/bugsplat-api-client.spec.ts
@@ -46,7 +46,7 @@ describe('BugSplatApiClient', () => {
         });
 
         it('should call fetch with correct route', () => {
-            expect((<any>client)._fetch).toHaveBeenCalledWith(`${fakeBugSplatHost}${route}`, jasmine.anything());
+            expect((client as any)._fetch).toHaveBeenCalledWith(`${fakeBugSplatHost}${route}`, jasmine.anything());
         });
 
         describe('when environment is Browser', () => {
@@ -59,7 +59,7 @@ describe('BugSplatApiClient', () => {
 
                 await client.fetch(route, init);
 
-                expect((<any>client)._fetch).toHaveBeenCalledWith(
+                expect((client as any)._fetch).toHaveBeenCalledWith(
                     jasmine.any(String),
                     jasmine.objectContaining({
                         body,
@@ -71,7 +71,7 @@ describe('BugSplatApiClient', () => {
 
         describe('when environment is Node', () => {
             it('should call fetch with cookie and xsrf-token headers in request init', () => {
-                expect((<any>client)._fetch).toHaveBeenCalledWith(
+                expect((client as any)._fetch).toHaveBeenCalledWith(
                     jasmine.any(String),
                     jasmine.objectContaining({
                         body,
@@ -98,7 +98,7 @@ describe('BugSplatApiClient', () => {
         beforeEach(async () => result = await client.login(email, password));
 
         it('should call fetch with correct url', () => {
-            expect((<any>client)._fetch).toHaveBeenCalledWith(`${fakeBugSplatHost}/api/authenticatev3`, jasmine.anything());
+            expect((client as any)._fetch).toHaveBeenCalledWith(`${fakeBugSplatHost}/api/authenticatev3`, jasmine.anything());
         });
     
         it('should append email, password and Login properties to formData', () => {
@@ -108,7 +108,7 @@ describe('BugSplatApiClient', () => {
         });
     
         it('should call fetch with formData', () => {
-            expect((<any>client)._fetch).toHaveBeenCalledWith(
+            expect((client as any)._fetch).toHaveBeenCalledWith(
                 jasmine.any(String),
                 jasmine.objectContaining({
                     method: 'POST',
@@ -125,7 +125,7 @@ describe('BugSplatApiClient', () => {
 
         describe('error', () => {
             it('should throw if response status is 401', async () => {
-                (<any>client)._fetch.and.returnValue({ status: 401 });
+                (client as any)._fetch.and.returnValue({ status: 401 });
                 
                 await expectAsync(client.login(email, password)).toBeRejectedWithError(
                     Error,
@@ -142,8 +142,8 @@ function createFakeBugSplatApiClient(
     formData
 ): BugSplatApiClient {
     const client = new BugSplatApiClient(fakeBugSplatHost, environment);
-    (<any>client)._fetch = jasmine.createSpy();
-    (<any>client)._fetch.and.returnValue(responseBody);
-    (<any>client)._createFormData = () => formData;
+    (client as any)._fetch = jasmine.createSpy();
+    (client as any)._fetch.and.returnValue(responseBody);
+    (client as any)._createFormData = () => formData;
     return client;
 }

--- a/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
+++ b/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
@@ -33,7 +33,7 @@ describe('OAuthClientCredentialsClient', () => {
             fakeAuthorizeResponseBody,
             fakeFormData
         );
-        (<any>sut)._fetch.and.returnValues(
+        (sut as any)._fetch.and.returnValues(
             Promise.resolve(fakeAuthorizeResponseBody),
             Promise.resolve(fakeFetchResponseBody)
         );
@@ -45,7 +45,7 @@ describe('OAuthClientCredentialsClient', () => {
         beforeEach(async () => result = await sut.login());
 
         it('should call fetch with correct url', () => {
-            expect((<any>sut)._fetch).toHaveBeenCalledWith(
+            expect((sut as any)._fetch).toHaveBeenCalledWith(
                 `${host}/oauth2/authorize`,
                 jasmine.anything()
             );
@@ -56,7 +56,7 @@ describe('OAuthClientCredentialsClient', () => {
             expect(fakeFormData.append).toHaveBeenCalledWith('client_id', clientId);
             expect(fakeFormData.append).toHaveBeenCalledWith('client_secret', clientSecret);
             expect(fakeFormData.append).toHaveBeenCalledWith('scope', 'restricted');
-            expect((<any>sut)._fetch).toHaveBeenCalledWith(
+            expect((sut as any)._fetch).toHaveBeenCalledWith(
                 jasmine.anything(),
                 jasmine.objectContaining({
                     method: 'POST',
@@ -104,14 +104,14 @@ describe('OAuthClientCredentialsClient', () => {
         });
 
         it('should call fetch with correct url', () => {
-            expect((<any>sut)._fetch).toHaveBeenCalledWith(
+            expect((sut as any)._fetch).toHaveBeenCalledWith(
                 `${host}${route}`,
                 jasmine.anything()
             );
         });
 
         it('should call fetch with init containing Authorization header', () => {
-            const mostRecentCallArgs = (<any>sut)._fetch.calls.mostRecent().args;
+            const mostRecentCallArgs = (sut as any)._fetch.calls.mostRecent().args;
             const headers = mostRecentCallArgs[1].headers;
             expect(headers).toEqual(jasmine.objectContaining({
                 ...headers,
@@ -120,11 +120,11 @@ describe('OAuthClientCredentialsClient', () => {
         });
 
         it('should call fetch with new init if init is not provided', async () => {
-            (<any>sut)._fetch.and.returnValue(Promise.resolve(fakeAuthorizeResponseBody));
+            (sut as any)._fetch.and.returnValue(Promise.resolve(fakeAuthorizeResponseBody));
 
             await sut.fetch(route);
 
-            const mostRecentCallArgs = (<any>sut)._fetch.calls.mostRecent().args;
+            const mostRecentCallArgs = (sut as any)._fetch.calls.mostRecent().args;
             const headers = mostRecentCallArgs[1].headers;
             expect(headers).toEqual(jasmine.objectContaining({
                 Authorization: `${fakeAuthorizeResult.token_type} ${fakeAuthorizeResult.access_token}`
@@ -139,7 +139,7 @@ describe('OAuthClientCredentialsClient', () => {
 
         describe('error', () => {
             it('should throw error with useful message if fetch returns 401', async () => {
-                (<any>sut)._fetch.and.resolveTo(createFakeResponseBody(401));
+                (sut as any)._fetch.and.resolveTo(createFakeResponseBody(401));
 
                 await expectAsync(sut.fetch(route)).toBeRejectedWithError(
                     Error,
@@ -158,9 +158,9 @@ function createFakeOAuthClientCredentialsClient(
     formData
 ): OAuthClientCredentialsClient {
     const client = new OAuthClientCredentialsClient(clientId, clientSecret, host);
-    (<any>client)._fetch = jasmine.createSpy();
-    (<any>client)._fetch.and.returnValue(responseBody);
-    (<any>client)._createFormData = () => formData;
+    (client as any)._fetch = jasmine.createSpy();
+    (client as any)._fetch.and.returnValue(responseBody);
+    (client as any)._createFormData = () => formData;
     return client;
 }
 

--- a/src/crash/crash-details/crash-details.spec.ts
+++ b/src/crash/crash-details/crash-details.spec.ts
@@ -45,11 +45,11 @@ describe('createCrashDetails', () => {
       processor: 'OBAN-10.0.7.144',
       comments: null,
       processed: ProcessingStatus.Complete,
-      thread: (<any>{ stackFrames: [], stackKeyId: 0 }),
+      thread: ({ stackFrames: [], stackKeyId: 0 } as any),
       status: CrashStatus.Open,
     };
 
-    const result = createCrashDetails(<any>options);
+    const result = createCrashDetails(options as any);
 
     expect(result.comments).toEqual('');
     expect(result.description).toEqual('');

--- a/src/crash/crash-details/crash-details.ts
+++ b/src/crash/crash-details/crash-details.ts
@@ -28,6 +28,7 @@ export enum CrashStatus {
   Open = 0,
   Closed = 1,
   Regression = 2,
+  Ignored = 3,
 }
 
 export interface CrashDetails {

--- a/src/crash/stack-frame/stack-frame.spec.ts
+++ b/src/crash/stack-frame/stack-frame.spec.ts
@@ -4,19 +4,19 @@ describe('stackFrame', () => {
 
   describe('constructor', () => {
     it('should throw if fileName is not a string', () => {
-      expect(() => new StackFrame(<any>{ fileName: {} })).toThrow();
+      expect(() => new StackFrame({ fileName: {} } as any)).toThrow();
     });
 
     it('should throw if functionName is not a string', () => {
-      expect(() => new StackFrame(<any>{ fileName: 'string', functionName: {} })).toThrow();
+      expect(() => new StackFrame({ fileName: 'string', functionName: {} } as any)).toThrow();
     });
 
     it('should throw if lineNumber is not a number', () => {
-      expect(() => new StackFrame(<any>{ fileName: 'string', functionName: 'another string', lineNumber: 'string' })).toThrow();
+      expect(() => new StackFrame({ fileName: 'string', functionName: 'another string', lineNumber: 'string' } as any)).toThrow();
     });
 
     it('should throw if stackFrameLevel is not a number', () => {
-      expect(() => new StackFrame(<any>{ fileName: 'string', functionName: 'another string', lineNumber: 0, stackFrameLevel: 'another string' })).toThrow();
+      expect(() => new StackFrame({ fileName: 'string', functionName: 'another string', lineNumber: 0, stackFrameLevel: 'another string' } as any)).toThrow();
     });
 
     it('should convert arguments to an array if it is an object', () => {
@@ -174,7 +174,7 @@ describe('stackFrame', () => {
     });
 
     it('should return empty string if fileName and lineNumber are falsy', () => {
-      const result = (new StackFrame(<any>{ fileName: '', lineNumber: null })).getLocation();
+      const result = (new StackFrame({ fileName: '', lineNumber: null } as any)).getLocation();
 
       expect(result).toEqual('');
     });
@@ -184,7 +184,7 @@ describe('stackFrame', () => {
     it('should split on / and return last item', () => {
       const expectedFileName = 'drill.ts';
 
-      const result = new StackFrame(<any>{ fileName: `./this/is/not/a/${expectedFileName}`, lineNumber: null }).getLocation();
+      const result = new StackFrame({ fileName: `./this/is/not/a/${expectedFileName}`, lineNumber: null } as any).getLocation();
 
       expect(result).toEqual(expectedFileName);
     });
@@ -192,7 +192,7 @@ describe('stackFrame', () => {
     it('should split on \\ and return last item', () => {
       const expectedFileName = 'black.ts';
 
-      const result = new StackFrame(<any>{ fileName: `.\\this\\suit\\is\\not\\${expectedFileName}`, lineNumber: null }).getLocation();
+      const result = new StackFrame({ fileName: `.\\this\\suit\\is\\not\\${expectedFileName}`, lineNumber: null } as any).getLocation();
 
       expect(result).toEqual(expectedFileName);
     });
@@ -200,7 +200,7 @@ describe('stackFrame', () => {
     it('should return correct file name if neither \\ or / exist in string', () => {
       const expectedFileName = 'lettuce turnip the beat.ts';
 
-      const result = new StackFrame(<any>{ fileName: expectedFileName, lineNumber: null }).getLocation();
+      const result = new StackFrame({ fileName: expectedFileName, lineNumber: null } as any).getLocation();
 
       expect(result).toEqual(expectedFileName);
     });

--- a/src/events/events-api-client/event.ts
+++ b/src/events/events-api-client/event.ts
@@ -23,7 +23,8 @@ export enum EventType {
   RemoveStackKeyDefect = 'RemoveStackKeyDefect',
   StackKeyDefectStatusOpen = 'StackKeyDefectStatusOpen',
   StackKeyDefectStatusClosed = 'StackKeyDefectStatusClosed',
-  StackKeyDefectStatusRegression = 'StackKeyDefectStatusRegression'
+  StackKeyDefectStatusRegression = 'StackKeyDefectStatusRegression',
+  StackKeyDefectStatusIgnored = 'StackKeyDefectStatusIgnored'
 }
 
 export function createEvents(events: Array<EventResponseObject>): Array<Event> {

--- a/src/versions/versions-api-client/versions-api-client.spec.ts
+++ b/src/versions/versions-api-client/versions-api-client.spec.ts
@@ -232,7 +232,7 @@ describe('VersionsApiClient', () => {
             }];
             timer = jasmine.createSpy();
             timer.and.resolveTo(0);
-            (<any>versionsApiClient)._timer = timer;
+            (versionsApiClient as any)._timer = timer;
 
             result = await versionsApiClient.postSymbols(
                 database,
@@ -273,7 +273,7 @@ describe('VersionsApiClient', () => {
         });
 
         it('should sleep between requests', () => {
-            expect((<any>versionsApiClient)._timer).toHaveBeenCalledWith(1000);
+            expect((versionsApiClient as any)._timer).toHaveBeenCalledWith(1000);
         });
 
         it('should return response', () => {


### PR DESCRIPTION
### Description

For crashes we want to close and not re-open via the regression workflow.

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
