### PR TITLE
fix: added URI encoding to versions endpoints

### DIFF
--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -44,8 +44,9 @@ export class VersionsApiClient {
     ): Promise<BugSplatResponse> {
         const appVersionsParam = appVersions
             .reduce((prev, curr) => [...prev, curr.application, curr.version], [] as Array<string>)
+            .map(encodeURIComponent)
             .join(',');
-        const route = `${this.route}?database=${encodeURIComponent(database)}&appVersions=${encodeURIComponent(appVersionsParam)}`;
+        const route = `${this.route}?database=${encodeURIComponent(database)}&appVersions=${appVersionsParam}`;
         const request = {
             method: 'DELETE',
             cache: 'no-cache',


### PR DESCRIPTION
### Description

Claude and I uri encoded the parameters to the versions endpoint.  After discussion with Bobby, we decided to URI-encode each version string separately, leaving them comma-separated.

Also added test with versions containing a plus character

Fixes DEV-219

### Checklist

- [x] Tested manually
- [x] Unit tests pass with no errors or warnings
- [x] Documentation updated (if applicable)
- [x] Reviewed by at least 1 other contributor
