### PR TITLE
fix: support Blob file input for Bun compatibility

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,6 +37,8 @@ module.exports = [
         URL: 'readonly',
         Response: 'readonly',
         ReadableStream: 'readonly',
+        Blob: 'readonly',
+        Uint8Array: 'readonly',
         process: 'readonly',
         HeadersInit: 'readonly',
         setTimeout: 'readonly'

--- a/src/common/file/bugsplat-file.ts
+++ b/src/common/file/bugsplat-file.ts
@@ -4,6 +4,6 @@ export class UploadableFile {
     constructor(
         public readonly name: string,
         public readonly size: number,
-        public readonly file: File | Buffer | ReadableStream
+        public readonly file: File | Blob | Buffer | ReadableStream
     ) { }
 }

--- a/src/common/file/symbol-file.ts
+++ b/src/common/file/symbol-file.ts
@@ -2,4 +2,4 @@ import { UploadableFile } from '@common';
 import type { ReadableStream } from 'node:stream/web';
 
 export type SymbolFile = UploadableFile & { dbgId?: string, lastModified?: Date, moduleName?: string, uncompressedSize: number };
-export type GZippedSymbolFile = Omit<Required<SymbolFile>, 'file'> &  { file: ReadableStream };
+export type GZippedSymbolFile = Omit<Required<SymbolFile>, 'file'> &  { file: ReadableStream | Blob };

--- a/src/symbols/symbols-api-client/symbols-api-client.spec.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.spec.ts
@@ -114,6 +114,42 @@ describe('SymbolsApiClient', () => {
             expect(result).toEqual([fakeUploadResponse]);
         });
 
+        describe('blob', () => {
+            let fakeBlob;
+
+            beforeEach(() => {
+                fakeBlob = new Blob([new Uint8Array([0x1f, 0x8b, 0x08, 0x00])], { type: 'application/gzip' });
+                files = [{ file: fakeBlob }];
+            });
+
+            it('should accept Blob as file input', async () => {
+                const result = await symbolsApiClient.postSymbols(database, application, version, files);
+
+                expect(result).toEqual([fakeUploadResponse]);
+            });
+
+            it('should upload Blob directly without tee', async () => {
+                await symbolsApiClient.postSymbols(database, application, version, files);
+
+                expect((symbolsApiClient as any)._s3ApiClient.uploadFileToPresignedUrl).toHaveBeenCalledWith(
+                    url,
+                    jasmine.objectContaining({
+                        file: fakeBlob
+                    }),
+                    jasmine.objectContaining({
+                        'content-encoding': 'gzip'
+                    })
+                );
+            });
+
+            it('should throw if Blob does not start with gzip magic bytes', () => {
+                fakeBlob = new Blob([new Uint8Array([0xde, 0xad])], { type: 'application/octet-stream' });
+                files = [{ file: fakeBlob }];
+
+                return expectAsync(symbolsApiClient.postSymbols(database, application, version, files)).toBeRejectedWithError(/is not a gzipped stream/);
+            });
+        });
+
         describe('error', () => {
             it('should release checkStream reader lock, cancel checkStream reader, and cancel checkStream', async () => {
                 const releaseLock = jasmine.createSpy('releaseLock');

--- a/src/symbols/symbols-api-client/symbols-api-client.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.ts
@@ -1,6 +1,7 @@
 import { ApiClient, BugSplatResponse, GZippedSymbolFile, S3ApiClient } from '@common';
 import { delay } from '../../common/delay';
 import { safeCancel } from '../../common/cancel';
+import type { ReadableStream } from 'node:stream/web';
 
 export class SymbolsApiClient {
     private readonly uploadUrl = '/symsrv/uploadUrl';
@@ -20,32 +21,44 @@ export class SymbolsApiClient {
     ): Promise<Array<BugSplatResponse>> {
         const promises = files
             .map(async (file) => {
-                const originalStream = file.file;
-                const [checkStream, uploadStream] = originalStream.tee();
-                const reader = checkStream.getReader();
-                try {
-                    const { value, done } = await reader.read();
-                    
-                    if (done) {
-                        throw new Error('Could not read symbol file stream');
-                    }
+                const originalFile = file.file;
 
-                    if (!this.isGzipMagicBytes(value)) {
+                // Blob path: Bun.file() returns a lazy Blob that streams from disk.
+                // Bun's fetch handles Blob bodies natively with proper content-length,
+                // unlike ReadableStream which causes chunked encoding issues with S3.
+                if (originalFile instanceof Blob) {
+                    const header = new Uint8Array(await originalFile.slice(0, 2).arrayBuffer());
+                    if (!this.isGzipMagicBytes(header)) {
                         throw new Error('Symbol file stream is not a gzipped stream');
                     }
-                } finally {
-                    // Teed streams cause the original stream to dequeue at the rate of the slowest stream.
-                    // If we don't cancel checkStream, the buffer will up to the size of the original stream.
-                    // Release the lock, so we can cancel the stream.
-                    // See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/tee and https://github.com/whatwg/streams/issues/1033#issuecomment-601471668
-                    reader.releaseLock();
-                    safeCancel(checkStream);
+                } else {
+                    const [checkStream, uploadStream] = originalFile.tee();
+                    const reader = checkStream.getReader();
+                    try {
+                        const { value, done } = await reader.read();
+
+                        if (done) {
+                            throw new Error('Could not read symbol file stream');
+                        }
+
+                        if (!this.isGzipMagicBytes(value)) {
+                            throw new Error('Symbol file stream is not a gzipped stream');
+                        }
+                    } finally {
+                        // Teed streams cause the original stream to dequeue at the rate of the slowest stream.
+                        // If we don't cancel checkStream, the buffer will up to the size of the original stream.
+                        // Release the lock, so we can cancel the stream.
+                        // See https://developer.mozilla.org/en-US/docs/Web/API/ReadableStream/tee and https://github.com/whatwg/streams/issues/1033#issuecomment-601471668
+                        reader.releaseLock();
+                        safeCancel(checkStream);
+                    }
+
+                    file.file = uploadStream;
                 }
 
                 let uploadResponse: globalThis.Response;
 
                 try {
-                    file.file = uploadStream;
                     const presignedUrl = await this.getPresignedUrl(
                         database,
                         application,
@@ -55,9 +68,9 @@ export class SymbolsApiClient {
                     const additionalHeaders = {
                         'content-encoding': 'gzip'
                     };
-    
+
                     uploadResponse = await this._s3ApiClient.uploadFileToPresignedUrl(presignedUrl, file, additionalHeaders);
-    
+
                     await this.postUploadComplete(
                         database,
                         application,
@@ -65,10 +78,12 @@ export class SymbolsApiClient {
                         file
                     );
                 } finally {
-                    // Unfortunately, the original stream gets locked when we tee it, so we can't cancel it directly.
-                    // When both teed streams are cancelled, the original stream _should_ also be cancelled.
-                    // There's not a lot of documentation on this, so we might be mistaken.
-                    safeCancel(uploadStream);
+                    if (!(originalFile instanceof Blob)) {
+                        // Unfortunately, the original stream gets locked when we tee it, so we can't cancel it directly.
+                        // When both teed streams are cancelled, the original stream _should_ also be cancelled.
+                        // There's not a lot of documentation on this, so we might be mistaken.
+                        safeCancel(file.file as ReadableStream);
+                    }
                 }
 
                 await this._timer(1000);
@@ -166,8 +181,8 @@ export class SymbolsApiClient {
         return response;
     }
 
-    private isGzipMagicBytes(buffer: Buffer) {
-        const view = new Uint8Array(buffer);
+    private isGzipMagicBytes(buffer: Buffer | Uint8Array) {
+        const view = buffer instanceof Uint8Array ? buffer : new Uint8Array(buffer);
         return view[0] === 0x1f && view[1] === 0x8b;
     }
 }


### PR DESCRIPTION
## Summary
- Adds `Blob` support to `GZippedSymbolFile.file` and `UploadableFile.file` types
- When `file.file` is a `Blob`, `postSymbols` validates gzip magic bytes via `slice(0, 2)` instead of `tee()`, and passes the Blob directly to S3 upload
- Existing `ReadableStream` path is unchanged

## Why
Bun's `fetch` cannot properly PUT a `ReadableStream` body to S3 presigned URLs — it sends chunked transfer encoding instead of honoring `content-length`, which S3 rejects. However, `Bun.file()` returns a lazy `Blob` that streams from disk, and Bun's `fetch` handles Blob bodies natively with proper `content-length`. This enables `@bugsplat/symbol-upload` to work with Bun-compiled executables.

## Test plan
- [x] All 234 existing tests pass
- [x] 3 new tests for Blob path (accept Blob, upload without tee, reject non-gzip Blob)
- [x] Build passes (both CJS and ESM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)