### PR TITLE
feat: surface nUploaded metric fields on dashboard and versions responses

### DIFF
--- a/src/dashboard/dashboard-api-client/dashboard-api-client.spec.ts
+++ b/src/dashboard/dashboard-api-client/dashboard-api-client.spec.ts
@@ -13,11 +13,26 @@ describe('DashboardApiClient', () => {
         status: 'success',
         database,
         volume30Day: 100,
+        uploaded30Day: 80,
         crashDataDays: 30,
         crashHistory: {
             totalRows: 1,
             totalCrashes: 100,
-            rows: [{ appName: 'All', series: [] }],
+            totalUploaded: 80,
+            rows: [
+                {
+                    appName: 'All',
+                    series: [
+                        {
+                            timestamp: 1700000000,
+                            totalCrashCount: 100,
+                            uploadedCount: 80,
+                            throttleCrashCount: 10,
+                            retireCrashCount: 5,
+                        },
+                    ],
+                },
+            ],
         },
         lastCrashTime: '2026-02-23T12:00:00Z',
         recentCrashes: [],
@@ -105,8 +120,11 @@ describe('DashboardApiClient', () => {
 
             expect(result.status).toEqual('success');
             expect(result.volume30Day).toEqual(100);
+            expect(result.uploaded30Day).toEqual(80);
             expect(result.crashDataDays).toEqual(30);
             expect(result.crashHistory.totalCrashes).toEqual(100);
+            expect(result.crashHistory.totalUploaded).toEqual(80);
+            expect(result.crashHistory.rows[0].series[0].uploadedCount).toEqual(80);
             expect(result.statusCounts.current.total).toEqual(9);
         });
 

--- a/src/dashboard/dashboard-api-client/dashboard-api-response.ts
+++ b/src/dashboard/dashboard-api-client/dashboard-api-response.ts
@@ -2,7 +2,8 @@ export interface DashboardApiResponse {
     status: string;
     database: string;
     volume30Day: number;
-    uploaded30Day: number;
+    /** Absent until the backend nUploaded change ships; callers should fall back to volume30Day. */
+    uploaded30Day?: number;
     crashDataDays: number;
     crashHistory: CrashHistory;
     lastCrashTime: string | null;
@@ -16,7 +17,8 @@ export interface DashboardApiResponse {
 export interface CrashHistory {
     totalRows: number;
     totalCrashes: number;
-    totalUploaded: number;
+    /** Absent until the backend nUploaded change ships; callers should fall back to totalCrashes. */
+    totalUploaded?: number;
     rows: Array<CrashHistoryRow>;
 }
 
@@ -29,7 +31,8 @@ export interface CrashHistoryRow {
 export interface CrashHistoryDataPoint {
     timestamp: number;
     totalCrashCount: number;
-    uploadedCount: number;
+    /** Absent until the backend nUploaded change ships; callers should fall back to totalCrashCount. */
+    uploadedCount?: number;
     throttleCrashCount: number;
     retireCrashCount: number;
     day?: number;

--- a/src/dashboard/dashboard-api-client/dashboard-api-response.ts
+++ b/src/dashboard/dashboard-api-client/dashboard-api-response.ts
@@ -2,6 +2,7 @@ export interface DashboardApiResponse {
     status: string;
     database: string;
     volume30Day: number;
+    uploaded30Day: number;
     crashDataDays: number;
     crashHistory: CrashHistory;
     lastCrashTime: string | null;
@@ -15,6 +16,7 @@ export interface DashboardApiResponse {
 export interface CrashHistory {
     totalRows: number;
     totalCrashes: number;
+    totalUploaded: number;
     rows: Array<CrashHistoryRow>;
 }
 
@@ -27,6 +29,7 @@ export interface CrashHistoryRow {
 export interface CrashHistoryDataPoint {
     timestamp: number;
     totalCrashCount: number;
+    uploadedCount: number;
     throttleCrashCount: number;
     retireCrashCount: number;
     day?: number;

--- a/src/versions/versions-api-row/version-api-row.spec.ts
+++ b/src/versions/versions-api-row/version-api-row.spec.ts
@@ -64,4 +64,20 @@ describe('VersionApiRow', () => {
 
         expect(result.periodCrashCount).toEqual(0);
     });
+
+    it('should convert periodUploadedCount string to number', () => {
+        const row = { periodUploadedCount: '42' };
+
+        const result = new VersionsApiRow(row as any);
+
+        expect(result.periodUploadedCount).toEqual(42);
+    });
+
+    it('should default periodUploadedCount to 0 when undefined', () => {
+        const row = {};
+
+        const result = new VersionsApiRow(row as any);
+
+        expect(result.periodUploadedCount).toEqual(0);
+    });
 });

--- a/src/versions/versions-api-row/versions-api-row.ts
+++ b/src/versions/versions-api-row/versions-api-row.ts
@@ -14,6 +14,7 @@ export interface VersionsApiResponseRow {
   fullDumps: '0' | '1';
   totalCrashCount: string;
   periodCrashCount: string;
+  periodUploadedCount: string;
 }
 
 export class VersionsApiRow {
@@ -30,6 +31,7 @@ export class VersionsApiRow {
   fullDumps: boolean;
   totalCrashCount: number;
   periodCrashCount: number;
+  periodUploadedCount: number;
 
   constructor(rawApiRow: VersionsApiResponseRow) {
     ac.assertType(rawApiRow, Object, 'rawApiRow');
@@ -58,6 +60,7 @@ export class VersionsApiRow {
     this.fullDumps = Boolean(Number(rawApiRow.fullDumps));
     this.totalCrashCount = Number(rawApiRow.totalCrashCount ?? 0);
     this.periodCrashCount = Number(rawApiRow.periodCrashCount ?? 0);
+    this.periodUploadedCount = Number(rawApiRow.periodUploadedCount ?? 0);
 
     Object.freeze(this);
   }

--- a/src/versions/versions-column.ts
+++ b/src/versions/versions-column.ts
@@ -1,5 +1,6 @@
 export type VersionsColumn =
   | 'periodCrashCount'
+  | 'periodUploadedCount'
   | 'percentOfTotal'
   | 'appName'
   | 'version'


### PR DESCRIPTION
## Summary

The BugSplat backend added a new crash metric `nUploaded` (crashes that actually landed) alongside the existing `nCrashes` (crashes accepted at the gate). This PR exposes the corresponding additive response fields in the SDK so consumers (the web-app Dashboard) can read them at runtime.

## Added fields (all additive)

**Dashboard** (`/api/dashboard.php` — pass-through response, interface-only):
- `DashboardApiResponse.uploaded30Day: number`
- `CrashHistory.totalUploaded: number`
- `CrashHistoryDataPoint` (series point): `uploadedCount: number`

**Versions v2** (`/api/v2/versions` — runtime-mapped `VersionsApiRow`):
- `VersionsApiResponseRow.periodUploadedCount: string` (raw JSON type)
- `VersionsApiRow.periodUploadedCount: number` **plus** the constructor mapping (`Number(rawApiRow.periodUploadedCount ?? 0)`), so the field is not silently dropped at runtime.

### Not modeled here
The backend PR also adds `nUploaded` fields to `crashHistory`, `databaseDetails`, `subscription`, and admin `dbSizes`. This SDK does not model those endpoints separately (there are no typed response models for them), so nothing was added for them — consistent with keeping the change scoped to what the SDK actually surfaces.

## Types vs runtime
Two cases were handled distinctly:
- **Dashboard** returns the parsed JSON directly (`return response.json()`), so adding the fields to the interfaces is sufficient.
- **Versions** constructs `VersionsApiRow` field-by-field in a constructor, so the new field was added to **both** the type and the runtime mapping and is proven to surface by a unit test.

## Verification
- `npm run build` (cjs + esm) — passes.
- `npm test` — 242 specs, 0 failures. Extended `dashboard-api-client.spec.ts` to assert `uploaded30Day`, `crashHistory.totalUploaded`, and series `uploadedCount` surface through the client; added `version-api-row.spec.ts` cases proving `periodUploadedCount` maps (string→number) and defaults to 0.
- `npx eslint` on the changed files — clean.

## References
- Backend: BugSplat-Git/webroot#1824
- Web-app: BugSplat-Git/bugsplat-web-app#3180

Additive only — no existing fields renamed or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)