### PR TITLE
feat(versions): add sharedSize to VersionsApiRow and VersionsColumn

### DIFF
--- a/src/versions/versions-api-row/version-api-row.spec.ts
+++ b/src/versions/versions-api-row/version-api-row.spec.ts
@@ -65,6 +65,22 @@ describe('VersionApiRow', () => {
         expect(result.periodCrashCount).toEqual(0);
     });
 
+    it('should convert sharedSize string to number', () => {
+        const row = { sharedSize: '19.4219' };
+
+        const result = new VersionsApiRow(row as any);
+
+        expect(result.sharedSize).toEqual(19.4219);
+    });
+
+    it('should default sharedSize to 0 when undefined', () => {
+        const row = {};
+
+        const result = new VersionsApiRow(row as any);
+
+        expect(result.sharedSize).toEqual(0);
+    });
+
     it('should convert periodUploadedCount string to number', () => {
         const row = { periodUploadedCount: '42' };
 

--- a/src/versions/versions-api-row/versions-api-row.ts
+++ b/src/versions/versions-api-row/versions-api-row.ts
@@ -8,6 +8,7 @@ export interface VersionsApiResponseRow {
   firstReport: string;
   lastReport: string;
   size: string;
+  sharedSize: string;
   reportsPerDay: string | null;
   rejectedCount: string;
   retired: '0' | '1';
@@ -25,6 +26,7 @@ export class VersionsApiRow {
   firstReport: string;
   lastReport: string;
   size: number;
+  sharedSize: number;
   reportsPerDay: number;
   rejectedCount: number;
   retired: boolean;
@@ -54,6 +56,8 @@ export class VersionsApiRow {
     this.firstReport = rawApiRow.firstReport;
     this.lastReport = rawApiRow.lastReport;
     this.size = Number(rawApiRow.size);
+    // Older backends omit sharedSize; default to 0 rather than NaN
+    this.sharedSize = Number(rawApiRow.sharedSize ?? 0);
     this.reportsPerDay = Number(safeReportsPerDay);
     this.rejectedCount = Number(rawApiRow.rejectedCount);
     this.retired = Boolean(Number(rawApiRow.retired));

--- a/src/versions/versions-api-row/versions-api-row.ts
+++ b/src/versions/versions-api-row/versions-api-row.ts
@@ -8,7 +8,8 @@ export interface VersionsApiResponseRow {
   firstReport: string;
   lastReport: string;
   size: string;
-  sharedSize: string;
+  // Optional: older backends predating schema 75 omit this field
+  sharedSize?: string;
   reportsPerDay: string | null;
   rejectedCount: string;
   retired: '0' | '1';

--- a/src/versions/versions-column.ts
+++ b/src/versions/versions-column.ts
@@ -5,6 +5,7 @@ export type VersionsColumn =
   | 'appName'
   | 'version'
   | 'size'
+  | 'sharedSize'
   | 'lastUpdate'
   | 'lastReport'
   | 'firstReport'


### PR DESCRIPTION
The versions API (webroot BugSplat-Git/webroot#1851, schema 74→75) now returns `sharedSize` — bytes in symbol files other versions also reference (stored once in S3, not freed by deleting the version) — alongside `size`, which became the exclusive/reclaimable remainder.

`VersionsApiRow`'s constructor copies an explicit field list and freezes the instance, so without this change the new field is silently stripped from every row and the web app's "Shared (not reclaimable)" column renders empty cells. Defaults to 0 for older backends that omit the field. `sharedSize` also joins the `VersionsColumn` union so it is sortable/filterable — the web app currently carries two `as VersionsColumn` casts that come out once this publishes.

Two new specs; 248 specs green.

**Sequencing:** merge/publish after webroot #1851 deploys; `bugsplat-web-app` then bumps its dependency to the released version (its matching `feature/exclusive-shared-symbol-sizes` branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)