### PR TITLE
feat: surface upload failures as typed BugSplatApiError with status

### DIFF
--- a/src/common/client/api-client.spec.ts
+++ b/src/common/client/api-client.spec.ts
@@ -1,4 +1,21 @@
-import { BugSplatRateLimitError } from './api-client';
+import { BugSplatApiError, BugSplatRateLimitError } from './api-client';
+
+describe('BugSplatApiError', () => {
+    it('should be marked as an api error', () => {
+        const error = new BugSplatApiError('forbidden', 403);
+
+        expect(error.isApiError).toBeTrue();
+        expect(error instanceof Error).toBeTrue();
+    });
+
+    it('should carry the response status', () => {
+        const error = new BugSplatApiError('forbidden', 403);
+
+        expect(error.status).toBe(403);
+        expect(error.message).toBe('forbidden');
+        expect(error.name).toBe('BugSplatApiError');
+    });
+});
 
 describe('BugSplatRateLimitError', () => {
     it('should be marked as a rate limit error', () => {
@@ -12,5 +29,13 @@ describe('BugSplatRateLimitError', () => {
         const error = new BugSplatRateLimitError('too many requests');
 
         expect(error.status).toBe(429);
+    });
+
+    it('should be a BugSplatApiError so status-based handling catches it too', () => {
+        const error = new BugSplatRateLimitError('too many requests');
+
+        expect(error instanceof BugSplatApiError).toBeTrue();
+        expect(error.isApiError).toBeTrue();
+        expect(error.name).toBe('BugSplatRateLimitError');
     });
 });

--- a/src/common/client/api-client.ts
+++ b/src/common/client/api-client.ts
@@ -15,8 +15,9 @@ export class BugSplatAuthenticationError extends Error {
 }
 
 /**
- * An unsuccessful HTTP response from the BugSplat API. Carries the status so callers can decide how to
- * react — for example retrying a 5xx or a 429, but failing fast on a 403 that no amount of retrying fixes.
+ * An unsuccessful HTTP response to a request this client made — either to the BugSplat API, or to the
+ * S3 presigned URL a symbol upload is PUT to. Carries the status so callers can decide how to react —
+ * for example retrying a 5xx or a 429, but failing fast on a 403 that no amount of retrying fixes.
  */
 export class BugSplatApiError extends Error {
     readonly isApiError = true;

--- a/src/common/client/api-client.ts
+++ b/src/common/client/api-client.ts
@@ -14,14 +14,31 @@ export class BugSplatAuthenticationError extends Error {
     readonly isAuthenticationError = true;
 }
 
-export class BugSplatRateLimitError extends Error {
-    readonly isRateLimitError = true;
+/**
+ * An unsuccessful HTTP response from the BugSplat API. Carries the status so callers can decide how to
+ * react — for example retrying a 5xx or a 429, but failing fast on a 403 that no amount of retrying fixes.
+ */
+export class BugSplatApiError extends Error {
+    readonly isApiError = true;
 
     constructor(
         message: string,
-        readonly status: number = 429
+        readonly status: number
     ) {
         super(message);
+        // The cjs build targets es5, where subclassing Error leaves instances on Error.prototype and
+        // breaks instanceof. Restore the chain so callers can use instanceof as well as isApiError.
+        Object.setPrototypeOf(this, BugSplatApiError.prototype);
+        this.name = 'BugSplatApiError';
+    }
+}
+
+export class BugSplatRateLimitError extends BugSplatApiError {
+    readonly isRateLimitError = true;
+
+    constructor(message: string, status = 429) {
+        super(message, status);
+        Object.setPrototypeOf(this, BugSplatRateLimitError.prototype);
         this.name = 'BugSplatRateLimitError';
     }
 }

--- a/src/common/client/index.ts
+++ b/src/common/client/index.ts
@@ -1,4 +1,4 @@
-export { ApiClient, BugSplatResponse, BugSplatAuthenticationError, BugSplatRateLimitError } from './api-client';
+export { ApiClient, BugSplatResponse, BugSplatApiError, BugSplatAuthenticationError, BugSplatRateLimitError } from './api-client';
 export { BugSplatApiClient } from './bugsplat-api-client/bugsplat-api-client';
 export { OAuthClientCredentialsClient } from './oauth-client-credentials-api-client/oauth-client-credentials-api-client';
 export { S3ApiClient } from './s3-api-client/s3-api-client';

--- a/src/common/client/s3-api-client/s3-api-client.spec.ts
+++ b/src/common/client/s3-api-client/s3-api-client.spec.ts
@@ -86,6 +86,18 @@ describe('S3ApiClient', () => {
 
                 await expectAsync(s3ApiClient.uploadFileToPresignedUrl(url, file)).toBeRejectedWithError(`Error uploading to presigned URL ${url}`);
             });
+
+            it('should throw a BugSplatApiError carrying the status', async () => {
+                const url = 'https://bugsplat.com';
+                const file = { name: '🐛.txt', size: 1337 } as any;
+                (s3ApiClient as any)._fetch.and.resolveTo({ status: 403 });
+
+                await expectAsync(s3ApiClient.uploadFileToPresignedUrl(url, file))
+                    .toBeRejectedWith(jasmine.objectContaining({
+                        isApiError: true,
+                        status: 403
+                    }));
+            });
         });
     });
 });

--- a/src/common/client/s3-api-client/s3-api-client.ts
+++ b/src/common/client/s3-api-client/s3-api-client.ts
@@ -1,4 +1,5 @@
 import { UploadableFile } from '@common';
+import { BugSplatApiError } from '../api-client';
 
 export class S3ApiClient {
 
@@ -17,7 +18,7 @@ export class S3ApiClient {
         } as RequestInit);
 
         if (response.status !== 200) {
-            throw new Error(`Error uploading to presigned URL ${presignedUrl}`);
+            throw new BugSplatApiError(`Error uploading to presigned URL ${presignedUrl}`, response.status);
         }
 
         return response;

--- a/src/symbols/symbols-api-client/symbols-api-client.spec.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.spec.ts
@@ -126,12 +126,13 @@ describe('SymbolsApiClient', () => {
                     }));
             });
 
-            it('should throw a BugSplatApiError with status 403 when credentials can\'t upload', async () => {
+            it('should throw a not authorized error naming the database when status is 403', async () => {
                 const fakeErrorResponse = createFakeResponseBody(403, {}, false);
                 apiClient.fetch.and.resolveTo(fakeErrorResponse as any);
 
                 await expectAsync(symbolsApiClient.postSymbols(database, application, version, files))
                     .toBeRejectedWith(jasmine.objectContaining({
+                        message: `Not authorized to upload symbols to ${database}, check the database name and that your credentials have access to it`,
                         isApiError: true,
                         status: 403
                     }));

--- a/src/symbols/symbols-api-client/symbols-api-client.spec.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.spec.ts
@@ -126,6 +126,28 @@ describe('SymbolsApiClient', () => {
                     }));
             });
 
+            it('should throw a BugSplatApiError with status 403 when credentials can\'t upload', async () => {
+                const fakeErrorResponse = createFakeResponseBody(403, {}, false);
+                apiClient.fetch.and.resolveTo(fakeErrorResponse as any);
+
+                await expectAsync(symbolsApiClient.postSymbols(database, application, version, files))
+                    .toBeRejectedWith(jasmine.objectContaining({
+                        isApiError: true,
+                        status: 403
+                    }));
+            });
+
+            it('should throw a BugSplatApiError carrying the status for other failures', async () => {
+                const fakeErrorResponse = createFakeResponseBody(500, {}, false);
+                apiClient.fetch.and.resolveTo(fakeErrorResponse as any);
+
+                await expectAsync(symbolsApiClient.postSymbols(database, application, version, files))
+                    .toBeRejectedWith(jasmine.objectContaining({
+                        isApiError: true,
+                        status: 500
+                    }));
+            });
+
             it('should release checkStream reader lock, cancel checkStream reader, and cancel checkStream', async () => {
                 const releaseLock = jasmine.createSpy('releaseLock');
                 fakeCheckStream = createFakeStream(new Uint8Array([]), false, releaseLock);

--- a/src/symbols/symbols-api-client/symbols-api-client.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.ts
@@ -1,4 +1,4 @@
-import { ApiClient, BugSplatRateLimitError, BugSplatResponse, GZippedSymbolFile, S3ApiClient } from '@common';
+import { ApiClient, BugSplatApiError, BugSplatRateLimitError, BugSplatResponse, GZippedSymbolFile, S3ApiClient } from '@common';
 import { delay } from '../../common/delay';
 import { safeCancel } from '../../common/cancel';
 
@@ -111,11 +111,11 @@ export class SymbolsApiClient {
         }
 
         if (response.status === 403) {
-            throw new Error('Error getting presigned URL, invalid credentials');
+            throw new BugSplatApiError('Error getting presigned URL, invalid credentials', response.status);
         }
 
         if (response.status !== 200) {
-            throw new Error(`Error getting presigned URL for ${file.name}`);
+            throw new BugSplatApiError(`Error getting presigned URL for ${file.name}`, response.status);
         }
 
         const json = await response.json() as Response & { url?: string };
@@ -155,7 +155,7 @@ export class SymbolsApiClient {
         const response = await this._client.fetch(this.uploadCompleteUrl, request);
 
         if (response.status !== 200) {
-            throw new Error(`Error completing symbol upload for ${file.name}, status ${response.status}`);
+            throw new BugSplatApiError(`Error completing symbol upload for ${file.name}, status ${response.status}`, response.status);
         }
 
         const json = await response.json() as Response & { url?: string };

--- a/src/symbols/symbols-api-client/symbols-api-client.ts
+++ b/src/symbols/symbols-api-client/symbols-api-client.ts
@@ -111,7 +111,10 @@ export class SymbolsApiClient {
         }
 
         if (response.status === 403) {
-            throw new BugSplatApiError('Error getting presigned URL, invalid credentials', response.status);
+            throw new BugSplatApiError(
+                `Not authorized to upload symbols to ${database}, check the database name and that your credentials have access to it`,
+                response.status
+            );
         }
 
         if (response.status !== 200) {

--- a/src/versions/versions-api-client/versions-api-client.spec.ts
+++ b/src/versions/versions-api-client/versions-api-client.spec.ts
@@ -368,7 +368,11 @@ describe('VersionsApiClient', () => {
                     application,
                     version,
                     files
-                )).toBeRejectedWithError('Error getting presigned URL, invalid credentials');
+                )).toBeRejectedWith(jasmine.objectContaining({
+                    message: 'Error getting presigned URL, invalid credentials',
+                    isApiError: true,
+                    status: 403
+                }));
             });
 
             it('should throw if response status is not 200, or 403', async () => {
@@ -380,7 +384,11 @@ describe('VersionsApiClient', () => {
                     application,
                     version,
                     files
-                )).toBeRejectedWithError(`Error getting presigned URL for ${files[0].name}`);
+                )).toBeRejectedWith(jasmine.objectContaining({
+                    message: `Error getting presigned URL for ${files[0].name}`,
+                    isApiError: true,
+                    status: 400
+                }));
             });
 
             it('should throw if response json Status is \'Failed\'', async () => {

--- a/src/versions/versions-api-client/versions-api-client.spec.ts
+++ b/src/versions/versions-api-client/versions-api-client.spec.ts
@@ -359,7 +359,7 @@ describe('VersionsApiClient', () => {
                 }));
             });
 
-            it('should throw if error with invalid credentials message if status is 403', async () => {
+            it('should throw a not authorized error naming the database if status is 403', async () => {
                 const fakeErrorResponse = createFakeResponseBody(403);
                 fakeBugSplatApiClient.fetch.and.resolveTo(fakeErrorResponse);
 
@@ -369,7 +369,7 @@ describe('VersionsApiClient', () => {
                     version,
                     files
                 )).toBeRejectedWith(jasmine.objectContaining({
-                    message: 'Error getting presigned URL, invalid credentials',
+                    message: `Not authorized to upload symbols to ${database}, check the database name and that your credentials have access to it`,
                     isApiError: true,
                     status: 403
                 }));

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -1,5 +1,6 @@
 import {
     ApiClient,
+    BugSplatApiError,
     BugSplatRateLimitError,
     BugSplatResponse,
     S3ApiClient,
@@ -137,8 +138,9 @@ export class VersionsApiClient {
 
         const response = await this._client.fetch(route, request);
         if (response.status !== 200) {
-            throw new Error(
-                `Error deleting symbols for ${database}-${application}-${version} status ${response.status}`
+            throw new BugSplatApiError(
+                `Error deleting symbols for ${database}-${application}-${version} status ${response.status}`,
+                response.status
             );
         }
 
@@ -208,11 +210,11 @@ export class VersionsApiClient {
         }
 
         if (response.status === 403) {
-            throw new Error('Error getting presigned URL, invalid credentials');
+            throw new BugSplatApiError('Error getting presigned URL, invalid credentials', response.status);
         }
 
         if (response.status !== 200) {
-            throw new Error(`Error getting presigned URL for ${file.name}`);
+            throw new BugSplatApiError(`Error getting presigned URL for ${file.name}`, response.status);
         }
 
         const json = (await response.json()) as Response & { url?: string };

--- a/src/versions/versions-api-client/versions-api-client.ts
+++ b/src/versions/versions-api-client/versions-api-client.ts
@@ -210,7 +210,10 @@ export class VersionsApiClient {
         }
 
         if (response.status === 403) {
-            throw new BugSplatApiError('Error getting presigned URL, invalid credentials', response.status);
+            throw new BugSplatApiError(
+                `Not authorized to upload symbols to ${database}, check the database name and that your credentials have access to it`,
+                response.status
+            );
         }
 
         if (response.status !== 200) {


### PR DESCRIPTION
## Problem

Every non-200 in the symbol upload path throws a bare `Error`, so consumers can only classify failures by matching on message strings.

The 403 is the one that bites. It's returned when credentials authenticate fine but aren't allowed to upload — wrong database, or a client without upload access:

```ts
if (response.status === 403) {
    throw new Error('Error getting presigned URL, invalid credentials');
}
```

Two problems in three lines:

1. **Untyped.** Downstream this is indistinguishable from a transient network failure, so [symbol-upload](https://github.com/BugSplat-Git/symbol-upload) retries it 15 times per file with up to 30s backoff — for a condition no amount of retrying can fix. Its only alternative is matching that message string, which silently breaks whenever the string changes.
2. **Misleading.** The credentials aren't invalid — invalid credentials come back 401 and already throw `BugSplatAuthenticationError`. Saying "invalid credentials" sends operators off rechecking a client secret that was never the problem, when the actual cause is usually a typo'd database name.

`BugSplatRateLimitError` (#168) already solved (1) for 429s by carrying `status`. This generalizes that, and fixes (2) while it's in there.

## Change

**Typed errors.** Add `BugSplatApiError` carrying the response status, and make `BugSplatRateLimitError` extend it so status-based handling catches 429s too:

```ts
export class BugSplatApiError extends Error {
    readonly isApiError = true;
    constructor(message: string, readonly status: number) { ... }
}

export class BugSplatRateLimitError extends BugSplatApiError { ... }
```

Thrown from the upload path — `getPresignedUrl` (symbols + versions), `postUploadComplete`, `deleteSymbols`, and the S3 PUT. Consumers get one rule instead of a growing list of special cases:

```ts
function isPermanent(error: unknown): boolean {
    const status = (error as BugSplatApiError | null)?.status;
    return !!status && status !== 408 && status !== 429 && status < 500;
}
```

**Accurate 403 message.** `Error getting presigned URL, invalid credentials` → `Not authorized to upload symbols to ${database}, check the database name and that your credentials have access to it`. Says what's actually wrong and names the database, so the fix is obvious from the CLI output. Every other message is unchanged.

### Prototype chain fix

While testing the built artifact I found `instanceof` never worked on these errors:

```
$ node -e "const {BugSplatRateLimitError:E} = require('@bugsplat/js-api-client'); \
           const e = new E('x'); console.log(e instanceof E, e.constructor.name)"
false Error
```

`tsconfig.cjs.json` overrides `target: es5`, where subclassing `Error` leaves instances on `Error.prototype`. So for anyone consuming the cjs entrypoint, `instanceof BugSplatRateLimitError` was `false` and `constructor.name` was `Error` — which is presumably why everything duck-types on `isRateLimitError` / `isAuthenticationError`. `Object.setPrototypeOf` in both constructors restores it; the esm build was already fine and is unaffected.

## Verification

- `npm test` — 254 specs, 0 failures
- `npm run build` and `npx eslint .` — clean
- Verified against the **built es5 cjs output**, not just ts-node, since that's where the prototype bug lives:

```
constructor.name          : BugSplatRateLimitError
rl instanceof barrel.RL   : true
rl instanceof barrel.Api  : true
duck-type (what consumers use): { isApiError: true, isRateLimitError: true, status: 429 }
```

New coverage: `BugSplatApiError` shape and the `BugSplatRateLimitError` inheritance in `api-client.spec.ts`; 403 and 500 cases in `symbols-api-client.spec.ts`; status assertions on the S3 client and the existing versions 403/400 cases.

## Notes

- **One breaking-ish detail:** the 403 message changed. Anyone matching the old string loses the match — but they now get `status`, which is the point. symbol-upload's bridge deliberately keeps matching the *old* string so it still handles 403s from older client versions ([symbol-upload#208](https://github.com/BugSplat-Git/symbol-upload/pull/208)).
- Otherwise additive and backwards compatible — `BugSplatRateLimitError` keeps `status`, `isRateLimitError`, its name and message; `instanceof Error` still holds everywhere.
- `BugSplatAuthenticationError` is deliberately untouched. It's thrown for non-HTTP cases too (XSRF parse failures), so giving it a `status` doesn't quite fit. It has the same es5 `instanceof` quirk if you want that fixed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
