### PR TITLE
fix: reject login when the authorize response carries no access_token

### DIFF
--- a/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
+++ b/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
@@ -86,6 +86,48 @@ describe('OAuthClientCredentialsClient', () => {
                     /Could not authenticate, check credentials and try again/
                 );
             });
+
+            it('should reject when the response carries no access_token', async () => {
+                // An unknown client id answers 400 with a message rather than an OAuth error payload.
+                sut = createLoginFailureClient(createFakeResponseBody(400, { message: 'Unknown clientId 🤷' }));
+
+                await expectAsync(sut.login()).toBeRejectedWith(jasmine.objectContaining({
+                    isAuthenticationError: true,
+                    message: 'Could not authenticate, check credentials and try again: Unknown clientId 🤷'
+                }));
+            });
+
+            it('should not store a token when the response carries no access_token', async () => {
+                sut = createLoginFailureClient(createFakeResponseBody(400, { message: 'Unknown clientId 🤷' }));
+
+                await expectAsync(sut.login()).toBeRejected();
+
+                expect((sut as any)._accessToken).toBeFalsy();
+                expect((sut as any)._tokenType).toBeFalsy();
+            });
+
+            it('should prefer error_description over other details', async () => {
+                sut = createLoginFailureClient(createFakeResponseBody(400, {
+                    error: 'invalid_request',
+                    error_description: 'grant_type is required',
+                    message: 'ignored'
+                }));
+
+                await expectAsync(sut.login()).toBeRejectedWithError(Error, /grant_type is required/);
+            });
+
+            it('should fall back to the status when the response carries no detail', async () => {
+                sut = createLoginFailureClient(createFakeResponseBody(500, {}));
+
+                await expectAsync(sut.login()).toBeRejectedWithError(
+                    Error,
+                    /Could not authenticate, check credentials and try again: status 500/
+                );
+            });
+
+            function createLoginFailureClient(responseBody) {
+                return createFakeOAuthClientCredentialsClient(clientId, clientSecret, host, responseBody, fakeFormData);
+            }
         });
     });
 

--- a/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
+++ b/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.spec.ts
@@ -106,6 +106,16 @@ describe('OAuthClientCredentialsClient', () => {
                 expect((sut as any)._tokenType).toBeFalsy();
             });
 
+            it('should reject a 2xx that carries no access_token', async () => {
+                // #142: a success status is not on its own proof that authentication succeeded.
+                sut = createLoginFailureClient(createFakeResponseBody(200, { token_type: 'Bearer' }));
+
+                await expectAsync(sut.login()).toBeRejectedWith(jasmine.objectContaining({
+                    isAuthenticationError: true,
+                    message: 'Could not authenticate, check credentials and try again: status 200'
+                }));
+            });
+
             it('should prefer error_description over other details', async () => {
                 sut = createLoginFailureClient(createFakeResponseBody(400, {
                     error: 'invalid_request',

--- a/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.ts
+++ b/src/common/client/oauth-client-credentials-api-client/oauth-client-credentials-api-client.ts
@@ -50,6 +50,16 @@ export class OAuthClientCredentialsClient implements ApiClient {
         }
 
         const loginResponse = responseJson as OAuthLoginResponse;
+
+        // Only a bad secret answers with `invalid_client`. An unknown client id comes back as
+        // 400 { "message": "Unknown clientId ..." }, which matches no error shape we look for — the
+        // absent token is the only signal that authentication failed. Without this login() resolves,
+        // the token stays empty, and every later request 401s in the middle of the caller's work.
+        if (!loginResponse.access_token) {
+            const detail = describeLoginFailure(responseJson, response.status);
+            throw new BugSplatAuthenticationError(`Could not authenticate, check credentials and try again: ${detail}`);
+        }
+
         this._accessToken = loginResponse.access_token;
         this._tokenType = loginResponse.token_type;
 
@@ -87,5 +97,11 @@ export class OAuthClientCredentialsClient implements ApiClient {
     }
 }
 
-type ErrorResponse = { error: string };
+/** Surfaces whatever the server said about the failure, so callers aren't left guessing at the cause. */
+function describeLoginFailure(responseJson: LoginResponse, status: number): string {
+    const errorResponse = responseJson as ErrorResponse;
+    return errorResponse.error_description ?? errorResponse.message ?? errorResponse.error ?? `status ${status}`;
+}
+
+type ErrorResponse = { error?: string, error_description?: string, message?: string };
 type LoginResponse = ErrorResponse | OAuthLoginResponse;


### PR DESCRIPTION
Closes #142

## Problem

`login()` decides authentication failed by matching one specific error string:

```ts
if ((responseJson as ErrorResponse).error === 'invalid_client') {
    throw new BugSplatAuthenticationError('Could not authenticate, check credentials and try again');
}

const loginResponse = responseJson as OAuthLoginResponse;
this._accessToken = loginResponse.access_token;   // undefined for an unknown client id
this._tokenType = loginResponse.token_type;       // undefined too

return response;                                   // ← resolves "successfully"
```

`invalid_client` is only sent for a **bad secret**. An **unknown client id** comes back as `400 { "message": "Unknown clientId ..." }`, which matches no shape being checked — so `login()` resolves, assigns `undefined` to both token fields, and hands back a client that sends `Authorization: undefined undefined` on every subsequent request.

The result is that an authentication failure doesn't surface at authentication time. It surfaces as a 401 in the middle of whatever the caller does next. Verified against the live API:

| credentials | authorize response | `login()` today |
| --- | --- | --- |
| valid | `200 {"token_type":"Bearer","access_token":"..."}` | resolves ✅ |
| bad secret | `200 {"error":"invalid_client",...}` | rejects ✅ |
| unknown client id | `400 {"message":"Unknown clientId ..."}` | **resolves** ❌ |

This is #142, filed against exactly the two assignment lines above: *"our backend might return a 2xx code for a client id/client secret authentication error with no token. We should check this case and fail fast."* The reproduction that led here was a 400 rather than a 2xx, but the cause is the same — the token is never checked, so the status it arrives with doesn't matter.

Downstream it's also [symbol-upload#178](https://github.com/BugSplat-Git/symbol-upload/issues/178): the CLI printed `Authentication success!` and then failed every single file upload. It's currently worked around in symbol-upload by re-reading the authorize body after `login()` resolves and checking for `access_token` — which only works because `BugSplatResponse.json()` happens to be `response.clone().json()`, a private implementation detail. Every other consumer of this library still has the bug.

## Change

Treat a missing `access_token` as the failure it is, and carry whatever the server said so the cause is visible:

```ts
if (!loginResponse.access_token) {
    const detail = describeLoginFailure(responseJson, response.status);
    throw new BugSplatAuthenticationError(`Could not authenticate, check credentials and try again: ${detail}`);
}
```

`describeLoginFailure` prefers `error_description`, then `message`, then `error`, falling back to `status ${status}` so the error is never bare.

The `invalid_client` branch is left exactly as it was. It's the one case with a precise meaning — the secret is wrong — and keeping it preserves its established message verbatim for anyone matching on it. Everything else falls through to the new check.

## Verification

- `npm test` — 259 specs, 0 failures (5 new)
- `npm run build` and `npx eslint .` — clean
- Exercised against the **built cjs output** across every payload shape:

```
unknown client id        -> threw isAuthError=true :: ...try again: Unknown clientId 0000...
bad secret               -> threw isAuthError=true :: ...check credentials and try again
oauth error_description  -> threw isAuthError=true :: ...try again: grant_type is required
no detail at all         -> threw isAuthError=true :: ...try again: status 500
valid                    -> RESOLVED, token="tok"
```

And the 2xx shapes #142 describes, all of which previously resolved with an empty token:

```
200, empty body                     -> threw isAuthError=true :: ...try again: status 200
200, token_type but no access_token -> threw isAuthError=true :: ...try again: status 200
200, empty-string token             -> threw isAuthError=true :: ...try again: status 200
204, no content                     -> threw isAuthError=true :: ...try again: status 204
```

New coverage: rejection on a missing token, the 2xx-without-token case from #142, that no token is stored when it happens, `error_description` precedence, and the status fallback.

## Notes

- **Behavior change, deliberately:** a call that used to resolve without a token now rejects. That's the bug. Anything that legitimately received a token is unaffected, and the `invalid_client` message is byte-identical.
- `fix:`, so semantic-release cuts a patch.
- Once this ships, symbol-upload deletes its authorize-response re-read entirely — staged in [symbol-upload#210](https://github.com/BugSplat-Git/symbol-upload/pull/210), which is draft until this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
